### PR TITLE
security: fix SSRF guard bypass via IPv6 transition addresses (GHSA-794r-5rp2-fpg8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.26.3] - 2026-05-30
+
+### Security
+- **SSRF guard bypass via IPv6 transition addresses** (GHSA-794r-5rp2-fpg8). `is_private_ip()` only range-checked the literal address, so IPv6 transition forms embedding a private/loopback IPv4 — IPv4-mapped (`::ffff:127.0.0.1`), IPv4-compatible (`::a.b.c.d`), 6to4 (`2002::/16`), and NAT64 (`64:ff9b::a9fe:a9fe`, encoding the `169.254.169.254` cloud-metadata endpoint) — were classified non-private and bypassed the SSRF allow/deny guard on 6to4/NAT64-enabled hosts. `is_private_ip()` now unwraps these transition forms via `_extract_embedded_ipv4()` and range-checks the embedded IPv4 in addition to the outer address. Public IPv4 embedded in a transition form stays allowed. Regression tests added in `tests/core/test_ssrf_ipv6_transition.py`.
+
 ## [2.27.0] - 2026-04-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flyto-core"
-version = "2.26.2"
+version = "2.26.3"
 description = "A workflow engine with 412 built-in modules. Trace every step. Replay from any point."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -334,9 +334,39 @@ class SSRFError(ValueError):
     pass
 
 
+def _extract_embedded_ipv4(ip):
+    """Return the IPv4 address embedded in an IPv6 transition address, else None.
+
+    Covers IPv4-mapped (``::ffff:a.b.c.d``), IPv4-compatible (``::a.b.c.d``),
+    6to4 (``2002::/16``) and NAT64 (well-known ``64:ff9b::/96`` and local-use
+    ``64:ff9b:1::/48``). These all carry an IPv4 endpoint that a 6to4/NAT64-enabled
+    kernel routes to, so the embedded IPv4 must be range-checked too — not only the
+    outer IPv6 form, which is not a member of any RFC 1918 / loopback range.
+    """
+    if ip.version != 6:
+        return None
+    if ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    if ip.sixtofour is not None:                 # 2002::/16
+        return ip.sixtofour
+    raw = int(ip).to_bytes(16, 'big')
+    # NAT64 well-known prefix 64:ff9b::/96 and local-use 64:ff9b:1::/48
+    if raw[:2] == b'\x00\x64' and (raw[2:4] == b'\xff\x9b' or raw[2:6] == b'\xff\x9b\x00\x01'):
+        return ipaddress.IPv4Address(raw[-4:])
+    # IPv4-compatible ::a.b.c.d (deprecated), excluding :: and ::1
+    if raw[:12] == bytes(12) and raw[12:] not in (bytes(4), b'\x00\x00\x00\x01'):
+        return ipaddress.IPv4Address(raw[-4:])
+    return None
+
+
 def is_private_ip(ip_str: str) -> bool:
     """
     Check if an IP address is in a private/internal range.
+
+    Also unwraps IPv6 transition forms (IPv4-mapped, IPv4-compatible, 6to4,
+    NAT64) and range-checks the embedded IPv4, so e.g. ``::ffff:127.0.0.1`` or
+    ``64:ff9b::a9fe:a9fe`` (NAT64 encoding of 169.254.169.254) are treated as
+    private/internal.
 
     Args:
         ip_str: IP address string
@@ -346,13 +376,18 @@ def is_private_ip(ip_str: str) -> bool:
     """
     try:
         ip = ipaddress.ip_address(ip_str)
-        for network in PRIVATE_IP_RANGES:
-            if ip in network:
-                return True
-        return False
     except ValueError:
         # Invalid IP, treat as potentially unsafe
         return True
+    candidates = [ip]
+    embedded = _extract_embedded_ipv4(ip)
+    if embedded is not None:
+        candidates.append(embedded)
+    for candidate in candidates:
+        for network in PRIVATE_IP_RANGES:
+            if candidate.version == network.version and candidate in network:
+                return True
+    return False
 
 
 def validate_url_ssrf(

--- a/tests/core/test_ssrf_ipv6_transition.py
+++ b/tests/core/test_ssrf_ipv6_transition.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Flyto2. Licensed under Apache-2.0. See LICENSE.
+
+"""Regression tests for SSRF guard handling of IPv6 transition addresses.
+
+The SSRF guard (`is_private_ip` / `validate_url_ssrf`) must treat IPv6
+transition forms (IPv4-mapped, IPv4-compatible, 6to4, NAT64) as private when
+their embedded IPv4 is private, so they cannot be used to bypass the guard and
+reach loopback / RFC 1918 / cloud-metadata endpoints.
+"""
+
+import pytest
+
+from core.utils import is_private_ip, validate_url_ssrf, SSRFError
+
+
+# (address, expected is_private_ip result, description)
+TRANSITION_PRIVATE = [
+    ("::ffff:127.0.0.1", "IPv4-mapped loopback"),
+    ("::ffff:169.254.169.254", "IPv4-mapped cloud metadata"),
+    ("::ffff:10.0.0.1", "IPv4-mapped RFC1918"),
+    ("64:ff9b::7f00:1", "NAT64-WKP loopback"),
+    ("64:ff9b::a9fe:a9fe", "NAT64-WKP cloud metadata"),
+    ("64:ff9b:1::a9fe:a9fe", "NAT64 local-use cloud metadata"),
+    ("2002:7f00:1::", "6to4 loopback"),
+    ("2002:a9fe:a9fe::", "6to4 cloud metadata"),
+    ("::7f00:1", "IPv4-compatible loopback"),
+]
+
+TRANSITION_PUBLIC = [
+    ("::ffff:8.8.8.8", "IPv4-mapped public"),
+    ("64:ff9b::808:808", "NAT64-WKP public (8.8.8.8)"),
+    ("2002:808:808::", "6to4 public (8.8.8.8)"),
+]
+
+NATIVE_PRIVATE = ["127.0.0.1", "169.254.169.254", "10.0.0.1", "::1", "fc00::1"]
+NATIVE_PUBLIC = ["8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"]
+
+
+@pytest.mark.parametrize("addr,desc", TRANSITION_PRIVATE)
+def test_transition_private_is_blocked(addr, desc):
+    assert is_private_ip(addr) is True, f"{desc} ({addr}) must be classified private"
+
+
+@pytest.mark.parametrize("addr,desc", TRANSITION_PUBLIC)
+def test_transition_public_is_allowed(addr, desc):
+    # Embedded IPv4 is public -> not private, must stay reachable.
+    assert is_private_ip(addr) is False, f"{desc} ({addr}) must be classified public"
+
+
+@pytest.mark.parametrize("addr", NATIVE_PRIVATE)
+def test_native_private_still_blocked(addr):
+    assert is_private_ip(addr) is True
+
+
+@pytest.mark.parametrize("addr", NATIVE_PUBLIC)
+def test_native_public_still_allowed(addr):
+    assert is_private_ip(addr) is False
+
+
+@pytest.mark.parametrize("addr,desc", TRANSITION_PRIVATE)
+def test_validate_url_ssrf_rejects_transition_literal(addr, desc):
+    # Literal-IP host on an allowed port; the guard must raise SSRFError.
+    with pytest.raises(SSRFError):
+        validate_url_ssrf(f"http://[{addr}]:8080/latest/meta-data/")


### PR DESCRIPTION
## SSRF guard bypass via IPv6 transition addresses — GHSA-794r-5rp2-fpg8

`is_private_ip()` in `src/core/utils.py` only range-checked the literal address against `PRIVATE_IP_RANGES`. IPv6 transition forms that embed a private/loopback IPv4 were classified **non-private** and bypassed the SSRF allow/deny guard in `validate_url_ssrf` on 6to4/NAT64-enabled hosts:

- IPv4-mapped `::ffff:127.0.0.1`
- IPv4-compatible `::a.b.c.d`
- 6to4 `2002::/16`
- NAT64 `64:ff9b::a9fe:a9fe` (encodes `169.254.169.254` — cloud metadata)

Impact: metadata/credential theft, internal port scans from a workflow-authored URL.

### Fix
- `src/core/utils.py` — add `_extract_embedded_ipv4()` to unwrap transition forms and range-check the embedded IPv4 in addition to the outer address. Public IPv4 embedded in a transition form stays allowed. (+43/-4)
- `tests/core/test_ssrf_ipv6_transition.py` — regression tests (IPv4-mapped/compatible/6to4/NAT64 private + public vectors, native private/public). (+64)
- Release bump to **2.26.3** + CHANGELOG `Security` entry.

### Verification
`tests/core/test_ssrf_ipv6_transition.py` — **29 passed** (pytest).

Patch authored on the GHSA private fork (`e68f4d8`), cherry-picked here with provenance preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
