### PR TITLE
ci(security): scanning baseline — gitleaks + pip-audit + dependabot + SHA-pinned actions (FLYA-17)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,15 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+
+  # Keep SHA-pinned GitHub Actions current — Dependabot bumps the pin and
+  # updates the trailing version comment, so pinning does not mean rotting.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+      - "ci"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -23,10 +23,10 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
@@ -42,7 +42,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -52,15 +52,15 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
@@ -100,7 +100,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
@@ -122,7 +122,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
@@ -131,7 +131,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1 (pinned, FLYA-18)
 
       - name: Trigger downstream rebuilds
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/regen-module-snapshot.yml
+++ b/.github/workflows/regen-module-snapshot.yml
@@ -14,10 +14,10 @@ jobs:
   regen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,79 @@
+name: Security Scan
+
+# FLYA-17 supply-chain baseline: secret scanning + dependency (CVE) scanning.
+# Runs on every push to main and on every PR (complete mediation), plus a
+# weekly schedule so newly disclosed CVEs in already-pinned deps are caught
+# without a code change. Fails closed: a finding fails the job.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Mondays 06:17 UTC — offset minute to avoid the top-of-hour runner stampede.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+# Least privilege: read-only token; no job here needs write.
+permissions:
+  contents: read
+
+concurrency:
+  group: security-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Scan the whole commit history, not just HEAD, so a secret committed
+          # earlier and later "removed" is still surfaced.
+          fetch-depth: 0
+
+      - name: Run gitleaks (pinned binary, checksum-verified)
+        env:
+          # Pin the gitleaks tool itself (not the org-licensed Action) and
+          # verify its checksum before executing — supply-chain integrity for
+          # our own tooling.
+          GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          set -euo pipefail
+          curl -sSL --retry 3 \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o gitleaks.tgz
+          echo "${GITLEAKS_SHA256}  gitleaks.tgz" | sha256sum -c -
+          tar -xzf gitleaks.tgz gitleaks
+          chmod +x gitleaks
+          # Scan committed history AND the current working tree. -c pins the
+          # repo's allowlist config explicitly (don't rely on auto-detection);
+          # --redact keeps any matched secret out of the public CI log;
+          # --exit-code 1 fails closed.
+          ./gitleaks git . -c .gitleaks.toml --redact --no-banner --exit-code 1
+          ./gitleaks dir . -c .gitleaks.toml --redact --no-banner --exit-code 1
+
+  dependency-scan:
+    name: Dependency scan (pip-audit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.11'
+
+      - name: Install pip-audit
+        run: pip install pip-audit==2.7.3
+
+      - name: Audit declared dependencies for known CVEs
+        # Resolves requirements.txt and fails (exit 1) when any resolved package
+        # has a known advisory in the OSV / PyPI advisory DB. We intentionally
+        # do NOT pass --strict here so an un-auditable package (no version info)
+        # does not mask real findings; revisit once the dep set is fully pinned.
+        run: pip-audit -r requirements.txt --progress-spinner=off

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,38 @@
+# gitleaks configuration — FLYA-17 supply-chain baseline.
+#
+# Posture: inherit the full default rule set (fail closed on real secrets) and
+# add only NARROW, justified allowlists for fixtures that were triaged as
+# benign. We deliberately do NOT blanket-ignore tests/ — a real secret in a
+# test file must still fail the gate. Each allowlist below names why it is safe.
+#
+# Triage record (2026-05-30, SecurityEngineer, FLYA-17):
+#   - workflows/pentests/*  : deliberate attack vectors (alg:none / forged-admin
+#                             JWTs) shipped as test data for the appsec product's
+#                             own crypto-pentest modules. Not live credentials.
+#   - jwt_verify.py example : truncated docstring placeholder "eyJ...HUzI1NiIs..."
+#   - test_security.py      : obvious placeholder key "sk-test123456789".
+# No live/production secret was found in source or history.
+
+title = "flyto-core gitleaks config"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Appsec product pentest fixtures: deliberate JWT/crypto attack vectors are test data, not live secrets. Residual risk: a real secret committed under this path would be missed — acceptable for a fixture-only directory; revisit if non-fixture files land here."
+paths = [
+  '''workflows/pentests/.*''',
+]
+
+[[allowlists]]
+description = "Build artifacts are gitignored and absent from CI checkout; allowlisting only keeps local `gitleaks dir` scans noise-free."
+paths = [
+  '''build/.*''',
+]
+
+[[allowlists]]
+description = "Documented placeholder/example tokens (truncated docstring example + obviously-fake test key). Matched by exact pattern, not by path, so a real key elsewhere is not masked."
+regexes = [
+  '''eyJhbGciOiJIUzI1NiIs\.\.\.''',
+  '''sk-test[0-9]+''',
+]


### PR DESCRIPTION
## FLYA-17 — supply-chain scanning baseline (pilot: flyto-core)

Pilot implementation of the org-wide dependency + secret scanning standard. Establishes the canonical pattern to fan out to the other published packages.

### What this adds
- **`security-scan.yml`** — runs on push to `main`, every PR, a weekly schedule, and manual dispatch. `permissions: contents: read` (least privilege).
  - **Secret scan (gitleaks 8.30.1)** — pinned binary, **checksum-verified** before exec, scans full git history *and* working tree, `--redact` (no secret in logs), `--exit-code 1` (fail-closed).
  - **Dependency scan (pip-audit)** — audits `requirements.txt` against the OSV/PyPI advisory DB; fails on known CVEs.
- **`.gitleaks.toml`** — narrow, documented allowlists for triaged-benign fixtures only (pentest attack vectors, a truncated docstring example token, a placeholder test key). No blanket `tests/` ignore.
- **`dependabot.yml`** — adds the `github-actions` ecosystem (pip already present) so SHA pins stay current.
- **SHA-pinned Actions** — all first-party `actions/*` in `publish-pypi.yml` + `regen-module-snapshot.yml` pinned to commit SHAs with version comments (`pypa/gh-action-pypi-publish` was already pinned in FLYA-18).

### Verification
Ran the exact gitleaks logic locally against this repo: **4 history / 5 working-tree findings WITHOUT `.gitleaks.toml`, 0 WITH it.** The gate demonstrably fails on secrets and passes clean. No live/production secret exists in source or history — all findings were example/fixture data.

### Security lenses
Secure Defaults · Fail Securely (exit-code 1) · Least Privilege (read-only token) · Complete Mediation (every push + PR) · Supply-chain integrity (checksum-verified pinned tool, SHA-pinned actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)