### PR TITLE
security: harden MCP bind policy + require_auth fail-closed (FLYA-32)

### DIFF
--- a/src/core/api/security.py
+++ b/src/core/api/security.py
@@ -111,9 +111,23 @@ async def require_auth(
     request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
 ):
-    """FastAPI dependency — validates Bearer token on protected endpoints."""
+    """FastAPI dependency — validates Bearer token on protected endpoints.
+
+    Fails closed (Secure Defaults / Fail Securely): if auth was never
+    initialized (``_active_token is None``) the request is refused rather than
+    passed through. ``init_auth`` always mints a token during normal startup
+    (``create_app`` calls it unconditionally), so a ``None`` token means the
+    server is misconfigured/uninitialized — in which case denying every
+    protected surface, including MCP module execution, is the safe default.
+    """
     if _active_token is None:
-        return  # Auth not initialized — pass through
+        # Latent fail-open removed: never serve a protected endpoint without
+        # active authentication. 503 distinguishes "auth not initialized"
+        # (server-side misconfiguration) from "bad/missing credentials" (401).
+        raise HTTPException(
+            status_code=503,
+            detail="Authentication is not initialized; refusing request",
+        )
 
     if not credentials or credentials.credentials != _active_token:
         raise HTTPException(status_code=401, detail="Invalid or missing auth token")
@@ -123,8 +137,18 @@ async def require_auth(
 # Bind Posture
 # ---------------------------------------------------------------------------
 
-# Hosts that only accept connections from the local machine.
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", ""})
+# Hosts that only accept connections from the local machine. An empty/unset
+# host, "0.0.0.0", "::", and "*" all resolve to "all interfaces" (INADDR_ANY /
+# in6addr_any) and are therefore NOT loopback — binding to them exposes the
+# server to the network. They must fall through to enforce_bind_policy's auth
+# check rather than being treated as a safe local bind (fail-open removed).
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+# Hosts that explicitly request all interfaces (INADDR_ANY / in6addr_any).
+# Treated as non-loopback unconditionally so a wildcard bind can never be
+# misclassified as a safe local bind — even if a future edit re-adds one of
+# these to _LOOPBACK_HOSTS (defense in depth around the fail-open we removed).
+_WILDCARD_HOSTS = frozenset({"", "0.0.0.0", "::", "*"})
 
 
 def is_auth_active() -> bool:
@@ -133,7 +157,10 @@ def is_auth_active() -> bool:
 
 
 def _is_loopback_host(host: str) -> bool:
-    return (host or "").strip().lower() in _LOOPBACK_HOSTS
+    normalized = (host or "").strip().lower()
+    if normalized in _WILDCARD_HOSTS:
+        return False  # all-interfaces bind is never loopback — refuse the shortcut
+    return normalized in _LOOPBACK_HOSTS
 
 
 def enforce_bind_policy(host: str) -> None:

--- a/tests/core/api/test_mcp_auth.py
+++ b/tests/core/api/test_mcp_auth.py
@@ -179,3 +179,60 @@ class TestBindPolicy:
 
         sec._active_token = "an-active-token"
         enforce_bind_policy("0.0.0.0")
+
+    # FLYA-32 hardening: an empty/wildcard host means "all interfaces"
+    # (INADDR_ANY / in6addr_any), not loopback. Previously "" lived in
+    # _LOOPBACK_HOSTS, so enforce_bind_policy("") returned early and skipped
+    # the auth check — a fail-open in the bind guard. These pin the fix.
+    @pytest.mark.parametrize("host", ["", " ", "0.0.0.0", "::", "*"])
+    def test_wildcard_host_without_auth_is_refused(self, host):
+        from core.api.security import enforce_bind_policy
+
+        sec._active_token = None
+        with pytest.raises(RuntimeError):
+            enforce_bind_policy(host)
+
+    @pytest.mark.parametrize("host", ["", "0.0.0.0", "::", "*"])
+    def test_wildcard_host_with_active_auth_is_allowed(self, host):
+        from core.api.security import enforce_bind_policy
+
+        sec._active_token = "an-active-token"
+        # With auth active a wildcard bind is the operator's explicit choice.
+        enforce_bind_policy(host)
+
+
+class TestMcpFailsClosedWhenAuthUninitialized:
+    """FLYA-32 hardening: the MCP exec surface must fail closed even when auth
+    was never initialized (`_active_token is None`). Previously `require_auth`
+    returned early ("pass through") in that state — a latent fail-open on the
+    shared dependency that would have left module execution wide open.
+    """
+
+    def setup_method(self):
+        self._saved = sec._active_token
+
+    def teardown_method(self):
+        sec._active_token = self._saved
+
+    def test_execute_module_with_uninitialized_auth_is_denied(self, app):
+        # create_app() ran init_auth(); simulate the uninitialized/misconfigured
+        # state by clearing the active token after construction.
+        sec._active_token = None
+        with TestClient(app) as client:
+            with patch(
+                "core.api.routes.mcp.handle_jsonrpc_request", new_callable=AsyncMock
+            ) as dispatch:
+                resp = client.post(
+                    "/mcp",
+                    json=EXECUTE_MODULE_CALL,
+                    headers={
+                        "Accept": "application/json",
+                        # Even a "matching" bearer must not succeed: there is no
+                        # active token to match against, so deny outright.
+                        "Authorization": "Bearer anything",
+                    },
+                )
+        # Fail closed: refused (not 2xx) and the dispatcher never runs.
+        assert resp.status_code >= 400, resp.text
+        assert resp.status_code not in (200,), resp.text
+        dispatch.assert_not_called()


### PR DESCRIPTION
## Defense-in-depth hardening (FLYA-32)

Follow-up to the GHSA-h9f9-h6gm-wc85 fix (now public, shipped in v2.26.4). **Neither change re-opens the advisory** — the `require_auth` gate on `/mcp` already closes unauthenticated module execution regardless of bind. These remove two latent fail-opens in the secondary defense layer.

### 1. Bind-guard fail-open: `""` was treated as loopback
`_LOOPBACK_HOSTS` included `""`. An empty/unset host binds to **all interfaces** (INADDR_ANY), so `enforce_bind_policy("")` returned early and skipped the auth-active refusal — fail-open in the bind guard.

- Drop `""` from `_LOOPBACK_HOSTS`.
- Add an explicit `_WILDCARD_HOSTS = {"", "0.0.0.0", "::", "*"}` invariant in `_is_loopback_host()`, so a wildcard bind can **never** be misclassified as a safe local bind — even if a future edit re-adds one to `_LOOPBACK_HOSTS` (defense in depth).

### 2. `require_auth` fail-open when auth uninitialized
When `_active_token is None`, the shared dependency passed the request through. `init_auth` always mints a token in normal startup (`create_app` calls it unconditionally), so this is unreachable in practice — but it's a latent fail-open on the dependency that guards **every** protected surface (modules/execute, workflow/run, replay, `/mcp`).

- `None` now **fails closed** with `503` (distinguishes "auth not initialized" / server misconfig from "bad credentials" / 401).
- Fixes the class, not just the MCP instance — Secure Defaults / Fail Securely.

### Regression tests (fail-first verified)
`tests/core/api/test_mcp_auth.py`:
- `enforce_bind_policy` raises for `""`, `" "`, `"0.0.0.0"`, `"::"`, `"*"` without active auth; allowed with auth active.
- `/mcp` `execute_module` is refused (and the JSON-RPC dispatcher is **never** invoked) when auth is uninitialized.

Verified the new assertions **fail against pre-fix code** (`""`/`" "` bind cases + uninitialized-auth case) and **pass after**. Full `tests/core/api/` suite: no new failures vs. baseline (12 pre-existing failures are a local Python 3.9 / PEP-604 `X | None` issue in `stability.py`, unrelated; CI runs 3.10+).

### Residual risk
None identified for these two vectors. The bind guard + `require_auth` now fail closed on empty/wildcard hosts and on the uninitialized-auth state. No PoC included (generic hardening).

Ref: FLYA-32 · follow-up to GHSA-h9f9-h6gm-wc85

🤖 Generated with [Claude Code](https://claude.com/claude-code)