### PR TITLE
fix(security): correct init_auth docstring + lock no-disabled-mode invariant (FLYA-41)

### DIFF
--- a/src/core/api/security.py
+++ b/src/core/api/security.py
@@ -82,7 +82,7 @@ def read_token_file(port: int) -> Optional[str]:
     return None
 
 
-def init_auth(port: int) -> Optional[str]:
+def init_auth(port: int) -> str:
     """
     Initialize auth token. Called once at startup.
 
@@ -90,7 +90,19 @@ def init_auth(port: int) -> Optional[str]:
     1. FLYTO_API_TOKEN env var — use as-is
     2. Auto-generate + write to file
 
-    Returns the active token, or None if auth is disabled.
+    Always mints and returns a non-empty bearer token: there is intentionally
+    **no auth-disabled mode**. Both paths set ``_active_token`` and return it, so
+    the return value is never None (the ``Optional`` was historical).
+
+    Design decision (FLYA-41): auth is on by default and fails closed. The
+    uninitialized ``_active_token is None`` state is reserved exclusively for
+    "auth not initialized / server misconfigured" and is rejected with 503 by
+    ``require_auth`` (see GHSA-h9f9-h6gm-wc85, FLYA-32) — it must never be
+    overloaded to mean "auth deliberately off". If an explicit auth-disabled
+    mode is ever genuinely needed, it MUST be gated behind a dedicated, loud env
+    flag (e.g. ``FLYTO_AUTH_DISABLED=1``) handled here so the intent is explicit
+    in logs and code — never inferred from a None token. No such flag exists
+    today, and any unrecognized one is ignored: this function still mints a token.
     """
     global _active_token
 

--- a/tests/core/api/test_routes.py
+++ b/tests/core/api/test_routes.py
@@ -434,6 +434,27 @@ class TestSecurityExtended:
         import core.api.security as sec
         sec._active_token = None
 
+    def test_init_auth_never_disabled(self, monkeypatch, tmp_path):
+        """Regression (FLYA-41): there is no auth-disabled mode.
+
+        init_auth always mints a non-empty token and never returns None, and an
+        unsupported FLYTO_AUTH_DISABLED env flag is ignored rather than silently
+        turning auth off. The None token state is reserved for "uninitialized"
+        (require_auth -> 503), never "deliberately disabled".
+        """
+        import core.api.security as sec
+        monkeypatch.setattr("core.api.security._TOKEN_DIR", tmp_path)
+        monkeypatch.delenv("FLYTO_API_TOKEN", raising=False)
+        monkeypatch.setenv("FLYTO_AUTH_DISABLED", "1")
+        from core.api.security import init_auth
+        token = init_auth(9997)
+        # Auth is NOT disabled by the unsupported flag — a real token is minted.
+        assert token is not None
+        assert token != ""
+        assert sec._active_token == token
+        # Clean up
+        sec._active_token = None
+
     def test_write_and_read_token_file(self, tmp_path, monkeypatch):
         monkeypatch.setattr("core.api.security._TOKEN_DIR", tmp_path)
         from core.api.security import write_token_file, read_token_file


### PR DESCRIPTION
Low-priority doc/clarity cleanup spun out of FLYA-32 review (merged as #22, `74e1796`). **No security exposure** — purely docstring + type-annotation accuracy plus an invariant-locking test.

## What & why
1. **Docstring fix.** `init_auth` claimed it "returns None if auth is disabled" — no such mode exists; both paths (env token / auto-generate) mint and return a token. Corrected the docstring and tightened the return annotation `Optional[str]` → `str` to match reality. Caller `server.py:68` (`if token:`) is unaffected.
2. **Decision documented (the second half of FLYA-41).** The uninitialized `_active_token is None` state is reserved exclusively for "auth not initialized / server misconfigured" — which `require_auth` now correctly rejects with **503** (fail-closed, GHSA-h9f9-h6gm-wc85 / FLYA-32). It must **never** be overloaded to mean "auth deliberately off." If an explicit auth-disabled mode is ever wanted, it MUST be gated behind a dedicated, loud env flag (e.g. `FLYTO_AUTH_DISABLED=1`) handled in `init_auth`, never inferred from a None token. No such flag exists today; an unrecognized one is ignored.

## Test
Adds `test_init_auth_never_disabled`: sets `FLYTO_AUTH_DISABLED=1` and asserts `init_auth` still mints a non-empty token (`_active_token` set). Locks the decision in code: no implicit/silent disabled mode. Existing `init_auth` tests unchanged.

Verified locally by exercising `init_auth` against the real module (fastapi stubbed, since local Py3.9 lacks the dep): `FLYTO_AUTH_DISABLED` ignored ✓, env-token path ✓, `require_auth` 503 fail-closed ✓. Full pytest runs in CI on 3.10+.

Lenses: Secure Defaults, Fail Securely, Open Design (decision explicit in code/logs, not inferred from state).

Closes FLYA-41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)