### PR TITLE
ci: branding guard [FLYA-42]

### DIFF
--- a/.github/branding-allowlist.txt
+++ b/.github/branding-allowlist.txt
@@ -1,0 +1,19 @@
+# branding-guard allowlist (FLYA-42 / parent FLYA-10/FLYA-38)
+# Each line is a fixed-string path the guard ignores. Two kinds:
+#   [data]     legitimate domain-as-data (recon fixtures, domain-canon
+#              logic, scanner examples) — NOT branding, keep permanently.
+#   [branding] not-yet-canonicalized legacy-domain (flyto2<dot>com) brand
+#              refs — remove once
+#              FLYA-38 migrates them to flyto.io so the guard goes active.
+# Best-effort classification; verify before deleting an entry.
+
+## [data] domain-as-data — keep
+examples/agent_demo/workflows/website_auditor.yaml
+src/core/engine/variable_resolver.py
+workflows/security_audit.yaml
+
+## [branding] pending FLYA-38 canonicalization — remove when migrated
+.github/FUNDING.yml
+README.md
+pyproject.toml
+src/cli/learn.py

--- a/.github/workflows/branding-guard.yml
+++ b/.github/workflows/branding-guard.yml
@@ -1,0 +1,58 @@
+name: Branding guard
+
+# Fails the PR when a non-canonical brand domain appears in source.
+# Canonical brand domain is flyto.io (FLYA-10 / FLYA-38). The npm scope
+# @flyto2/... is intentionally allowlisted until the package-rename
+# sub-decision lands.
+#
+# A per-repo .github/branding-allowlist.txt parks legitimate occurrences:
+#   - domain-as-data (recon test fixtures, domain-canonicalization logic,
+#     scanner doc examples) that are NOT branding and must never be migrated;
+#   - branding refs not yet canonicalized, tracked in FLYA-38.
+# Each line is a fixed-string path/substring; lines starting with # are
+# comments. Remove a branding entry once FLYA-38 migrates it so the guard
+# becomes fully active for that surface.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for non-canonical brand domain
+        run: |
+          # Build the banned domain from parts so this workflow never matches
+          # itself. Drop the allowlisted npm scope @flyto2/... first.
+          banned="flyto2${DOT}com"
+          allow=.github/branding-allowlist.txt
+          hits=$(grep -rnI "$banned" . \
+            --exclude-dir=.git \
+            --exclude-dir=node_modules \
+            --exclude=branding-allowlist.txt \
+            --exclude=branding-guard.yml \
+            | grep -v "@flyto2/" || true)
+          if [ -n "$hits" ] && [ -f "$allow" ]; then
+            pats=$(grep -vE '^[[:space:]]*(#|$)' "$allow" || true)
+            if [ -n "$pats" ]; then
+              hits=$(printf '%s\n' "$hits" | grep -vF -f <(printf '%s\n' "$pats") || true)
+            fi
+          fi
+          hits=$(printf '%s' "$hits" | sed '/^[[:space:]]*$/d')
+          if [ -n "$hits" ]; then
+            echo "::error::Non-canonical brand domain found ($banned). Canonical is flyto.io (FLYA-10):"
+            echo "$hits"
+            echo "If a hit is legitimate domain-as-data (not branding), add its path to $allow with a tracking comment."
+            exit 1
+          fi
+          echo "no non-canonical brand domain references"
+        env:
+          DOT: "."


### PR DESCRIPTION
Replicates the `branding-guard.yml` from flyto-design-tokens so non-canonical `flyto2.com` references cannot reappear (FLYA-42, parent FLYA-38/FLYA-10).

- Banned domain is built from parts so the workflow never self-matches; `@flyto2/` npm scope allowlisted.
- `.github/branding-allowlist.txt` parks legitimate domain-as-data (recon fixtures, domain-canon logic) and not-yet-canonicalized brand refs (remove as FLYA-38 migrates them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)