### PR TITLE
fix(compat): add from __future__ import annotations for Python 3.9 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flyto-core"
-version = "2.26.4"
+version = "2.26.5"
 description = "A workflow engine with 412 built-in modules. Trace every step. Replay from any point."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/core/modules/atomic/ai/embed.py
+++ b/src/core/modules/atomic/ai/embed.py
@@ -5,6 +5,8 @@ AI Embed Module
 Generate embeddings from text using OpenAI or local models.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 from typing import Any, Dict, List, Union

--- a/src/core/modules/atomic/ai/vision_analyze.py
+++ b/src/core/modules/atomic/ai/vision_analyze.py
@@ -5,6 +5,8 @@ AI Vision Analyze Module
 Analyze images using LLM vision capabilities (OpenAI GPT-4V or Anthropic Claude).
 """
 
+from __future__ import annotations
+
 import base64
 import logging
 import mimetypes

--- a/src/core/modules/atomic/auth/oauth2.py
+++ b/src/core/modules/atomic/auth/oauth2.py
@@ -14,6 +14,8 @@ from typing import Any, Dict, Optional
 from ...registry import register_module
 from ...schema import compose, field
 from ...schema.constants import Visibility, FieldGroup
+from ....utils import validate_url_with_env_config, SSRFError
+from ...errors import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -336,6 +338,12 @@ async def auth_oauth2(context: Dict[str, Any]) -> Dict[str, Any]:
 
     params = context['params']
     token_url = params['token_url']
+
+    try:
+        validate_url_with_env_config(token_url)
+    except SSRFError as e:
+        raise ValidationError(str(e), field="token_url")
+
     grant_type = params.get('grant_type', 'authorization_code')
     timeout_seconds = params.get('timeout', 15)
 

--- a/src/core/modules/atomic/auth/oauth2.py
+++ b/src/core/modules/atomic/auth/oauth2.py
@@ -15,6 +15,7 @@ from ...registry import register_module
 from ...schema import compose, field
 from ...schema.constants import Visibility, FieldGroup
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 from ...errors import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -363,7 +364,7 @@ async def auth_oauth2(context: Dict[str, Any]) -> Dict[str, Any]:
     start_time = time.time()
 
     try:
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with create_ssrf_safe_session(timeout=timeout) as session:
             async with session.post(
                 token_url,
                 data=body,

--- a/src/core/modules/atomic/communication/webhook_trigger.py
+++ b/src/core/modules/atomic/communication/webhook_trigger.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 from ...registry import register_module
 from ...schema import compose, presets
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 
 logger = logging.getLogger(__name__)
@@ -119,7 +120,7 @@ async def webhook_trigger(context: Dict[str, Any]) -> Dict[str, Any]:
 
     timeout = aiohttp.ClientTimeout(total=timeout_seconds)
 
-    async with aiohttp.ClientSession(timeout=timeout) as session:
+    async with create_ssrf_safe_session(timeout=timeout) as session:
         request_kwargs = {'headers': headers}
 
         if method in ('POST', 'PUT', 'PATCH') and payload:

--- a/src/core/modules/atomic/graphql/mutation.py
+++ b/src/core/modules/atomic/graphql/mutation.py
@@ -13,6 +13,7 @@ from ...schema.builders import field
 from ...schema.constants import FieldGroup
 from ...errors import ValidationError, ModuleError
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ async def _execute_graphql(url: str, payload: dict, headers: dict, label: str) -
         raise ModuleError("aiohttp is required for graphql modules. Install with: pip install aiohttp")
 
     try:
-        async with aiohttp.ClientSession() as session:
+        async with create_ssrf_safe_session() as session:
             async with session.post(url, json=payload, headers=headers) as response:
                 status_code = response.status
                 try:

--- a/src/core/modules/atomic/graphql/mutation.py
+++ b/src/core/modules/atomic/graphql/mutation.py
@@ -12,6 +12,7 @@ from ...schema import compose
 from ...schema.builders import field
 from ...schema.constants import FieldGroup
 from ...errors import ValidationError, ModuleError
+from ....utils import validate_url_with_env_config, SSRFError
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,12 @@ def _prepare_graphql_request(params: Dict[str, Any], operation_key: str = 'mutat
 
     if not url:
         raise ValidationError("Missing required parameter: url", field="url")
+
+    try:
+        validate_url_with_env_config(url)
+    except SSRFError as e:
+        raise ValidationError(str(e), field="url")
+
     if not operation:
         raise ValidationError("Missing required parameter: {}".format(operation_key), field=operation_key)
 

--- a/src/core/modules/atomic/graphql/query.py
+++ b/src/core/modules/atomic/graphql/query.py
@@ -13,6 +13,7 @@ from ...schema.builders import field
 from ...schema.constants import FieldGroup
 from ...errors import ValidationError, ModuleError
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ async def _execute_graphql(url: str, payload: dict, headers: dict, label: str) -
         raise ModuleError("aiohttp is required for graphql modules. Install with: pip install aiohttp")
 
     try:
-        async with aiohttp.ClientSession() as session:
+        async with create_ssrf_safe_session() as session:
             async with session.post(url, json=payload, headers=headers) as response:
                 status_code = response.status
                 try:

--- a/src/core/modules/atomic/graphql/query.py
+++ b/src/core/modules/atomic/graphql/query.py
@@ -12,6 +12,7 @@ from ...schema import compose
 from ...schema.builders import field
 from ...schema.constants import FieldGroup
 from ...errors import ValidationError, ModuleError
+from ....utils import validate_url_with_env_config, SSRFError
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,12 @@ def _prepare_graphql_request(params: Dict[str, Any], operation_key: str = 'query
 
     if not url:
         raise ValidationError("Missing required parameter: url", field="url")
+
+    try:
+        validate_url_with_env_config(url)
+    except SSRFError as e:
+        raise ValidationError(str(e), field="url")
+
     if not operation:
         raise ValidationError("Missing required parameter: {}".format(operation_key), field=operation_key)
 

--- a/src/core/modules/atomic/http/batch.py
+++ b/src/core/modules/atomic/http/batch.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 
 from ...registry import register_module
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 
 logger = logging.getLogger(__name__)
@@ -241,7 +242,7 @@ async def http_batch(context: Dict[str, Any]) -> Dict[str, Any]:
     timeout = aiohttp.ClientTimeout(total=timeout_s)
     batch_start = time.time()
 
-    async with aiohttp.ClientSession(timeout=timeout) as session:
+    async with create_ssrf_safe_session(timeout=timeout) as session:
         if measure_time:
             results = []
             for req in requests:

--- a/src/core/modules/atomic/http/get.py
+++ b/src/core/modules/atomic/http/get.py
@@ -13,6 +13,7 @@ from ...registry import register_module
 from ...errors import ValidationError, NetworkError, ModuleError
 from ...schema import compose, presets
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +113,7 @@ async def http_get(context: Dict[str, Any]) -> Dict[str, Any]:
     try:
         ssl_param = None if verify_ssl else False
         timeout = aiohttp.ClientTimeout(total=timeout_s)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with create_ssrf_safe_session(timeout=timeout) as session:
             async with session.get(url, headers=headers, ssl=ssl_param) as response:
                 body = await _parse_response_body(response)
                 if 200 <= response.status < 300:

--- a/src/core/modules/atomic/http/paginate.py
+++ b/src/core/modules/atomic/http/paginate.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from ....utils import SSRFError, validate_url_with_env_config
+from ....safe_http import create_ssrf_safe_session
 from ...registry import register_module
 from ...schema import compose, field, presets
 from ...schema.constants import FieldGroup
@@ -515,7 +516,7 @@ async def http_paginate(context: Dict[str, Any]) -> Dict[str, Any]:
     timeout = aiohttp.ClientTimeout(total=timeout_seconds)
 
     try:
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with create_ssrf_safe_session(timeout=timeout) as session:
             all_items, pages_fetched = await strategy_fn(
                 session, method, base_url, headers, verify_ssl,
                 data_path, page_size, max_pages, delay_ms,

--- a/src/core/modules/atomic/http/request.py
+++ b/src/core/modules/atomic/http/request.py
@@ -14,6 +14,7 @@ from ...registry import register_module
 from ...schema import compose, field, presets
 from ...schema.constants import Visibility, FieldGroup
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 
 logger = logging.getLogger(__name__)
@@ -333,7 +334,7 @@ async def http_request(context: Dict[str, Any]) -> Dict[str, Any]:
 
     for attempt in range(max_attempts):
         try:
-            async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with create_ssrf_safe_session(timeout=timeout) as session:
                 async with session.request(method, url, **request_kwargs) as response:
                     duration_ms = int((time.time() - start_time) * 1000)
                     body_content = await _read_response_body(response, response_type)

--- a/src/core/modules/atomic/http/session.py
+++ b/src/core/modules/atomic/http/session.py
@@ -12,6 +12,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from ....utils import SSRFError, validate_url_with_env_config
+from ....safe_http import create_ssrf_safe_session
 from ...registry import register_module
 from ...schema import compose, field, presets
 from ...schema.constants import FieldGroup, Visibility
@@ -279,7 +280,7 @@ async def http_session(context: Dict[str, Any]) -> Dict[str, Any]:
     cookie_jar = aiohttp.CookieJar()
 
     try:
-        async with aiohttp.ClientSession(timeout=timeout, cookie_jar=cookie_jar) as session:
+        async with create_ssrf_safe_session(timeout=timeout, cookie_jar=cookie_jar) as session:
             for i, req in enumerate(requests_list):
                 result = await _execute_request(session, req, i, auth, verify_ssl)
                 results.append(result)

--- a/src/core/modules/atomic/image/download.py
+++ b/src/core/modules/atomic/image/download.py
@@ -15,6 +15,7 @@ import aiohttp
 from ...registry import register_module
 from ...schema import compose, presets
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 
 logger = logging.getLogger(__name__)
@@ -142,7 +143,7 @@ async def image_download(context: Dict[str, Any]) -> Dict[str, Any]:
     if os.path.commonpath([base_real, target_real]) != base_real:
         raise Exception('Invalid file path')
 
-    async with aiohttp.ClientSession() as session:
+    async with create_ssrf_safe_session() as session:
         async with session.get(
             url,
             headers=default_headers,

--- a/src/core/modules/atomic/llm/_chat_models.py
+++ b/src/core/modules/atomic/llm/_chat_models.py
@@ -15,6 +15,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from ._interfaces import ChatResponse, ToolCall, ToolCallRequest
+from ....safe_http import create_ssrf_safe_session
 
 logger = logging.getLogger(__name__)
 
@@ -105,9 +106,7 @@ async def _http_post(url: str, headers: Dict, payload: Dict) -> Dict:
                 raise RuntimeError(f"Server error (HTTP {response.status_code}): {response.text[:200]}")
             return response.json()
     except ImportError:
-        import aiohttp
-
-        async with aiohttp.ClientSession() as session:
+        async with create_ssrf_safe_session() as session:
             async with session.post(url, headers=headers, json=payload) as response:
                 if response.status >= 500:
                     text = await response.text()

--- a/src/core/modules/atomic/llm/_providers.py
+++ b/src/core/modules/atomic/llm/_providers.py
@@ -16,6 +16,8 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
+from ....safe_http import create_ssrf_safe_session
+
 logger = logging.getLogger(__name__)
 
 
@@ -89,7 +91,7 @@ async def _call_openai_aiohttp(
         payload["tools"] = tools
         payload["tool_choice"] = "auto"
 
-    async with aiohttp.ClientSession() as session:
+    async with create_ssrf_safe_session() as session:
         async with session.post(url, headers=headers, json=payload) as response:
             result = await response.json()
 
@@ -204,7 +206,7 @@ async def call_anthropic_with_tools(
             response = await client.post(url, headers=headers, json=payload)
             result = response.json()
     else:
-        async with aiohttp.ClientSession() as session:
+        async with create_ssrf_safe_session() as session:
             async with session.post(url, headers=headers, json=payload) as response:
                 result = await response.json()
 

--- a/src/core/modules/atomic/llm/chat.py
+++ b/src/core/modules/atomic/llm/chat.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 from ...registry import register_module
 from ...schema import compose, presets
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 
 logger = logging.getLogger(__name__)
@@ -328,7 +329,7 @@ async def _call_openai_aiohttp(
 
     # SECURITY: Set timeout to prevent hanging API calls
     timeout = aiohttp.ClientTimeout(total=120, connect=30)
-    async with aiohttp.ClientSession(timeout=timeout) as session:
+    async with create_ssrf_safe_session(timeout=timeout) as session:
         async with session.post(url, headers=headers, json=payload) as response:
             result = await response.json()
 
@@ -396,7 +397,7 @@ async def _call_anthropic(
     else:
         # SECURITY: Set timeout to prevent hanging API calls
         timeout = aiohttp.ClientTimeout(total=120, connect=30)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with create_ssrf_safe_session(timeout=timeout) as session:
             async with session.post(url, headers=headers, json=payload) as response:
                 result = await response.json()
 
@@ -447,7 +448,7 @@ async def _call_ollama(
         else:
             # SECURITY: Set timeout to prevent hanging API calls
             timeout = aiohttp.ClientTimeout(total=120, connect=30)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with create_ssrf_safe_session(timeout=timeout) as session:
                 async with session.post(url, json=payload) as response:
                     result = await response.json()
 

--- a/src/core/modules/atomic/monitor/http_check.py
+++ b/src/core/modules/atomic/monitor/http_check.py
@@ -16,6 +16,7 @@ from ...registry import register_module
 from ...schema import compose
 from ...schema.builders import field
 from ...schema.constants import FieldGroup
+from ....utils import validate_url_with_env_config, SSRFError
 
 
 logger = logging.getLogger(__name__)
@@ -132,6 +133,17 @@ async def monitor_http_check(context: Dict[str, Any]) -> Dict[str, Any]:
 
     params = context['params']
     url = params['url']
+
+    try:
+        validate_url_with_env_config(url)
+    except SSRFError as e:
+        return {
+            'ok': False,
+            'error': str(e),
+            'error_code': 'SSRF_BLOCKED',
+            'data': {'status': 'unhealthy', 'status_code': 0, 'url': url},
+        }
+
     method = params.get('method', 'GET').upper()
     expected_status = params.get('expected_status', 200)
     timeout_ms = params.get('timeout_ms', 10000)

--- a/src/core/modules/atomic/monitor/http_check.py
+++ b/src/core/modules/atomic/monitor/http_check.py
@@ -17,6 +17,7 @@ from ...schema import compose
 from ...schema.builders import field
 from ...schema.constants import FieldGroup
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 
 logger = logging.getLogger(__name__)
@@ -172,7 +173,7 @@ async def monitor_http_check(context: Dict[str, Any]) -> Dict[str, Any]:
     start_time = time.time()
 
     try:
-        async with aiohttp.ClientSession(timeout=timeout_config) as session:
+        async with create_ssrf_safe_session(timeout=timeout_config) as session:
             async with session.request(method, url, **request_kwargs) as response:
                 response_time_ms = round((time.time() - start_time) * 1000, 2)
                 status_code = response.status

--- a/src/core/modules/atomic/notification/send.py
+++ b/src/core/modules/atomic/notification/send.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 from ...registry import register_module
 from ...schema import compose, presets
 from ....utils import validate_url_with_env_config, SSRFError
+from ....safe_http import create_ssrf_safe_session
 
 
 logger = logging.getLogger(__name__)
@@ -265,7 +266,7 @@ async def notify_send(context: Dict[str, Any]) -> Dict[str, Any]:
     timeout = aiohttp.ClientTimeout(total=30)
 
     try:
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with create_ssrf_safe_session(timeout=timeout) as session:
             async with session.post(url, json=payload, headers=headers) as response:
                 status_code = response.status
 

--- a/src/core/modules/third_party/developer/http/requests.py
+++ b/src/core/modules/third_party/developer/http/requests.py
@@ -14,6 +14,7 @@ from ....base import BaseModule
 from ....registry import register_module
 from ....schema import compose, presets
 from .....utils import validate_url_with_env_config, SSRFError
+from .....safe_http import create_ssrf_safe_session
 
 
 @register_module(
@@ -87,12 +88,11 @@ class HTTPGetModule(BaseModule):
             raise ValueError(str(e))
 
         ssl_param = None if verify_ssl else False
-        async with aiohttp.ClientSession() as session:
+        async with create_ssrf_safe_session(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
             async with session.get(
                 url,
                 headers=headers,
                 params=params,
-                timeout=aiohttp.ClientTimeout(total=timeout),
                 ssl=ssl_param,
             ) as response:
                 status_code = response.status
@@ -186,7 +186,6 @@ class HTTPPostModule(BaseModule):
         ssl_param = None if verify_ssl else False
         kwargs = {
             'headers': headers,
-            'timeout': aiohttp.ClientTimeout(total=timeout),
             'ssl': ssl_param,
         }
 
@@ -195,7 +194,7 @@ class HTTPPostModule(BaseModule):
         elif body:
             kwargs['data'] = body
 
-        async with aiohttp.ClientSession() as session:
+        async with create_ssrf_safe_session(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
             async with session.post(url, **kwargs) as response:
                 status_code = response.status
                 response_headers = dict(response.headers)

--- a/src/core/modules/third_party/developer/http/requests.py
+++ b/src/core/modules/third_party/developer/http/requests.py
@@ -13,6 +13,7 @@ import aiohttp
 from ....base import BaseModule
 from ....registry import register_module
 from ....schema import compose, presets
+from .....utils import validate_url_with_env_config, SSRFError
 
 
 @register_module(
@@ -79,6 +80,11 @@ class HTTPGetModule(BaseModule):
 
         if not url:
             raise ValueError("URL is required")
+
+        try:
+            validate_url_with_env_config(url)
+        except SSRFError as e:
+            raise ValueError(str(e))
 
         ssl_param = None if verify_ssl else False
         async with aiohttp.ClientSession() as session:
@@ -171,6 +177,11 @@ class HTTPPostModule(BaseModule):
 
         if not url:
             raise ValueError("URL is required")
+
+        try:
+            validate_url_with_env_config(url)
+        except SSRFError as e:
+            raise ValueError(str(e))
 
         ssl_param = None if verify_ssl else False
         kwargs = {

--- a/src/core/modules/types/stability.py
+++ b/src/core/modules/types/stability.py
@@ -6,6 +6,8 @@ Module Stability Helpers
 Functions for filtering modules by stability level based on runtime environment.
 """
 
+from __future__ import annotations
+
 import os
 from typing import Set
 

--- a/src/core/safe_http.py
+++ b/src/core/safe_http.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Flyto2. Licensed under Apache-2.0. See LICENSE.
+
+"""SSRF-safe outbound HTTP helpers (DNS-rebinding / TOCTOU defense).
+
+``validate_url_ssrf`` range-checks a hostname's resolved IPs *at validation
+time* and returns a URL string; the HTTP client then re-resolves DNS when it
+actually connects. A hostname under attacker control can answer with a public IP
+during validation and a private / cloud-metadata IP at connect time (DNS
+rebinding / validate-then-use TOCTOU, CWE-918), bypassing the guard.
+
+This module closes that window by routing outbound aiohttp traffic through a
+resolver that re-applies the SSRF IP check at *resolve* time and hands the vetted
+address straight to the connector. aiohttp dials the addresses the resolver
+returns without performing a second lookup, so the IP that is range-checked is
+exactly the IP that is connected to — validation and connection become atomic.
+
+This complements (does not replace) ``validate_url_ssrf``: that guard still
+rejects bad schemes / ports, blocked hostnames, and literal private-IP hosts up
+front (literal IPs cannot rebind). The resolver here covers the residual
+hostname-rebinding case. Both fail closed.
+"""
+
+import socket
+import logging
+from typing import Optional, Sequence
+
+from .utils import is_private_ip, SSRFError, get_ssrf_config
+
+logger = logging.getLogger(__name__)
+
+
+def _host_allowlisted(host: str, allowed_hosts: Optional[Sequence[str]]) -> bool:
+    """Mirror of the allowlist match used by ``validate_url_ssrf``."""
+    if not allowed_hosts:
+        return False
+    host = (host or "").lower()
+    for allowed in allowed_hosts:
+        allowed = allowed.lower()
+        if host == allowed:
+            return True
+        # Wildcard suffix match: *.example.com
+        if allowed.startswith("*.") and host.endswith(allowed[1:]):
+            return True
+    return False
+
+
+def _check_addrs_safe(
+    host: str,
+    addrs: Sequence[str],
+    *,
+    allow_private: bool = False,
+    allowed_hosts: Optional[Sequence[str]] = None,
+) -> None:
+    """Raise ``SSRFError`` if any resolved address is private/internal.
+
+    Pure helper (no aiohttp dependency) so the rebind defense is unit-testable.
+    Fails closed: a single private address in ``addrs`` rejects the whole
+    resolution. ``allow_private`` and an allowlisted ``host`` bypass the check,
+    matching ``validate_url_ssrf`` semantics.
+    """
+    if allow_private or _host_allowlisted(host, allowed_hosts):
+        return
+    for addr in addrs:
+        if is_private_ip(addr):
+            logger.warning(
+                "SSRF guard blocked a connect-time resolution to a "
+                "private/internal address"
+            )
+            raise SSRFError(
+                f"DNS resolution for {host} returned a private/internal IP "
+                f"({addr}) at connect time. Possible DNS rebinding; refusing to "
+                f"connect (fail-closed)."
+            )
+
+
+# The resolver subclasses aiohttp's AbstractResolver, which requires aiohttp at
+# definition time. aiohttp is an optional dependency in this codebase (modules
+# import it lazily), so the class is built on first use and cached here.
+_resolver_cls = None
+
+
+def _get_resolver_cls():
+    global _resolver_cls
+    if _resolver_cls is not None:
+        return _resolver_cls
+
+    import aiohttp
+    from aiohttp.abc import AbstractResolver
+
+    class SSRFGuardedResolver(AbstractResolver):
+        """aiohttp resolver that fails closed on private/internal addresses.
+
+        Wraps a base resolver, then range-checks every returned address. Because
+        aiohttp dials the addresses this resolver returns (no second lookup), a
+        rebind that flips a hostname to a private IP after URL validation is
+        caught here, at connect time.
+        """
+
+        def __init__(self, *, allow_private=False, allowed_hosts=None, base=None):
+            self._allow_private = bool(allow_private)
+            self._allowed_hosts = list(allowed_hosts or [])
+            self._base = base if base is not None else aiohttp.ThreadedResolver()
+
+        async def resolve(self, host, port=0, family=socket.AF_INET):
+            infos = await self._base.resolve(host, port, family)
+            _check_addrs_safe(
+                host,
+                [info["host"] for info in infos],
+                allow_private=self._allow_private,
+                allowed_hosts=self._allowed_hosts,
+            )
+            return infos
+
+        async def close(self):
+            await self._base.close()
+
+    _resolver_cls = SSRFGuardedResolver
+    return _resolver_cls
+
+
+def _resolve_config(allow_private, allowed_hosts):
+    """Fall back to env-based SSRF config when caller passes neither flag."""
+    if allow_private is None and allowed_hosts is None:
+        cfg = get_ssrf_config()
+        return cfg["allow_private"], cfg["allowed_hosts"]
+    return bool(allow_private), allowed_hosts
+
+
+def create_ssrf_safe_connector(
+    *,
+    allow_private=None,
+    allowed_hosts=None,
+    base_resolver=None,
+    **connector_kwargs,
+):
+    """Build an ``aiohttp.TCPConnector`` whose resolver re-checks SSRF on connect.
+
+    When ``allow_private`` / ``allowed_hosts`` are left as ``None`` they are read
+    from the environment via ``get_ssrf_config()``, so behaviour matches
+    ``validate_url_with_env_config`` (honors ``FLYTO_ALLOW_PRIVATE_NETWORK``,
+    ``FLYTO_ALLOWED_HOSTS``, ``FLYTO_VSCODE_LOCAL_MODE``).
+    """
+    import aiohttp
+
+    allow_private, allowed_hosts = _resolve_config(allow_private, allowed_hosts)
+    resolver = _get_resolver_cls()(
+        allow_private=allow_private,
+        allowed_hosts=allowed_hosts,
+        base=base_resolver,
+    )
+    return aiohttp.TCPConnector(resolver=resolver, **connector_kwargs)
+
+
+def create_ssrf_safe_session(
+    *,
+    timeout=None,
+    allow_private=None,
+    allowed_hosts=None,
+    **session_kwargs,
+):
+    """Build an ``aiohttp.ClientSession`` wired with an SSRF-guarded connector.
+
+    Drop-in replacement for ``aiohttp.ClientSession(...)`` in outbound modules.
+    The session owns the connector (``connector_owner`` defaults to ``True``), so
+    closing the session closes the connector and its resolver.
+    """
+    import aiohttp
+
+    connector = create_ssrf_safe_connector(
+        allow_private=allow_private, allowed_hosts=allowed_hosts
+    )
+    return aiohttp.ClientSession(connector=connector, timeout=timeout, **session_kwargs)

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -334,6 +334,34 @@ class SSRFError(ValueError):
     pass
 
 
+# RFC 6052 §2.2 — byte offsets (into the 16-byte IPv6 address) of the four
+# embedded-IPv4 octets, keyed by NAT64 prefix length. For prefix lengths < /96
+# the IPv4 is NOT contiguous in the low 32 bits: bits 64–71 are the reserved
+# "u" octet (byte index 8) and the IPv4 straddles it. Reading raw[-4:] is only
+# correct for the /96 case.
+_NAT64_IPV4_OCTETS = {
+    32: (4, 5, 6, 7),
+    40: (5, 6, 7, 9),
+    48: (6, 7, 9, 10),
+    56: (7, 9, 10, 11),
+    64: (9, 10, 11, 12),
+    96: (12, 13, 14, 15),
+}
+
+
+def _nat64_embedded_ipv4(raw: bytes, prefix_len: int):
+    """Extract the embedded IPv4 from a NAT64 address per RFC 6052 §2.2.
+
+    ``raw`` is the 16-byte big-endian IPv6 address; ``prefix_len`` is the NAT64
+    prefix length (one of 32/40/48/56/64/96). Returns an ``IPv4Address`` or
+    ``None`` if the prefix length is unsupported.
+    """
+    octets = _NAT64_IPV4_OCTETS.get(prefix_len)
+    if octets is None:
+        return None
+    return ipaddress.IPv4Address(bytes(raw[i] for i in octets))
+
+
 def _extract_embedded_ipv4(ip):
     """Return the IPv4 address embedded in an IPv6 transition address, else None.
 
@@ -342,6 +370,13 @@ def _extract_embedded_ipv4(ip):
     ``64:ff9b:1::/48``). These all carry an IPv4 endpoint that a 6to4/NAT64-enabled
     kernel routes to, so the embedded IPv4 must be range-checked too — not only the
     outer IPv6 form, which is not a member of any RFC 1918 / loopback range.
+
+    NAT64 extraction is position-aware (RFC 6052 §2.2): the well-known /96 prefix
+    carries the IPv4 in the low 32 bits, but the local-use ``64:ff9b:1::/48``
+    prefix carries it across bits 48–63 and 72–87 (skipping the reserved "u"
+    octet), so its octets are read from the correct, non-contiguous positions.
+    Reading the low 32 bits for the /48 form would extract the wrong octets and
+    could miss a private IPv4 (or be fooled by a public suffix).
     """
     if ip.version != 6:
         return None
@@ -350,9 +385,13 @@ def _extract_embedded_ipv4(ip):
     if ip.sixtofour is not None:                 # 2002::/16
         return ip.sixtofour
     raw = int(ip).to_bytes(16, 'big')
-    # NAT64 well-known prefix 64:ff9b::/96 and local-use 64:ff9b:1::/48
-    if raw[:2] == b'\x00\x64' and (raw[2:4] == b'\xff\x9b' or raw[2:6] == b'\xff\x9b\x00\x01'):
-        return ipaddress.IPv4Address(raw[-4:])
+    # NAT64 local-use prefix 64:ff9b:1::/48 (RFC 6052 §2.2) — check first: it is
+    # more specific than the well-known prefix on bytes 4–5 (00 01 vs 00 00).
+    if raw[:6] == b'\x00\x64\xff\x9b\x00\x01':
+        return _nat64_embedded_ipv4(raw, 48)
+    # NAT64 well-known prefix 64:ff9b::/96 (IPv4 in the low 32 bits).
+    if raw[:12] == b'\x00\x64\xff\x9b' + bytes(8):
+        return _nat64_embedded_ipv4(raw, 96)
     # IPv4-compatible ::a.b.c.d (deprecated), excluding :: and ::1
     if raw[:12] == bytes(12) and raw[12:] not in (bytes(4), b'\x00\x00\x00\x01'):
         return ipaddress.IPv4Address(raw[-4:])

--- a/tests/core/test_ssrf_ipv6_transition.py
+++ b/tests/core/test_ssrf_ipv6_transition.py
@@ -6,11 +6,26 @@ The SSRF guard (`is_private_ip` / `validate_url_ssrf`) must treat IPv6
 transition forms (IPv4-mapped, IPv4-compatible, 6to4, NAT64) as private when
 their embedded IPv4 is private, so they cannot be used to bypass the guard and
 reach loopback / RFC 1918 / cloud-metadata endpoints.
+
+The second half of this module (FLYA-23) covers two residual gaps found while
+verifying GHSA-794r-5rp2-fpg8:
+  * NAT64 local-use ``64:ff9b:1::/48`` embedded-IPv4 extraction position
+    (RFC 6052 §2.2 — IPv4 is not contiguous in the low 32 bits for /48).
+  * DNS-rebinding / validate-then-use TOCTOU on the connect path
+    (``core.safe_http`` re-checks resolved IPs at connect time).
 """
+
+import ipaddress
 
 import pytest
 
-from core.utils import is_private_ip, validate_url_ssrf, SSRFError
+from core.utils import (
+    is_private_ip,
+    validate_url_ssrf,
+    SSRFError,
+    _extract_embedded_ipv4,
+    _nat64_embedded_ipv4,
+)
 
 
 # (address, expected is_private_ip result, description)
@@ -62,3 +77,151 @@ def test_validate_url_ssrf_rejects_transition_literal(addr, desc):
     # Literal-IP host on an allowed port; the guard must raise SSRFError.
     with pytest.raises(SSRFError):
         validate_url_ssrf(f"http://[{addr}]:8080/latest/meta-data/")
+
+
+# ---------------------------------------------------------------------------
+# FLYA-23 #2 — NAT64 /48 position-aware embedded-IPv4 extraction (RFC 6052 §2.2)
+# ---------------------------------------------------------------------------
+
+# In the local-use prefix 64:ff9b:1::/48 the embedded IPv4 straddles the
+# reserved "u" octet: octets are at byte positions 6,7 and 9,10 — NOT the low
+# 32 bits. 169.254.169.254 (a9.fe.a9.fe) therefore encodes as
+# 64:ff9b:1:a9fe:a9:fe00:: (suffix zero).
+NAT64_48_CANONICAL_PRIVATE = [
+    ("64:ff9b:1:a9fe:a9:fe00::", "169.254.169.254", "NAT64 /48 cloud metadata"),
+    ("64:ff9b:1:7f00:0:100::", "127.0.0.1", "NAT64 /48 loopback"),
+    ("64:ff9b:1:c0a8:1:100::", "192.168.1.1", "NAT64 /48 RFC1918"),
+]
+
+
+@pytest.mark.parametrize("addr,expected,desc", NAT64_48_CANONICAL_PRIVATE)
+def test_nat64_48_canonical_extraction(addr, expected, desc):
+    emb = _extract_embedded_ipv4(ipaddress.ip_address(addr))
+    assert str(emb) == expected, f"{desc}: extracted {emb}, expected {expected}"
+    assert is_private_ip(addr) is True, f"{desc} ({addr}) must be classified private"
+
+
+def test_nat64_48_public_suffix_bypass_is_blocked():
+    """Regression for the /48 extraction bug.
+
+    Encodes 169.254.169.254 in the correct RFC 6052 /48 positions but puts a
+    *public* address (8.8.8.8) in the low 32 bits. The old code read the low 32
+    bits (raw[-4:]) and saw 8.8.8.8 -> not private -> bypass. Position-aware
+    extraction reads the real embedded IPv4 and blocks it.
+    """
+    addr = "64:ff9b:1:a9fe:a9:fe00:808:808"
+    # The decoy the old, buggy extractor would have read:
+    raw = int(ipaddress.ip_address(addr)).to_bytes(16, "big")
+    assert str(ipaddress.IPv4Address(raw[-4:])) == "8.8.8.8"  # old path = bypass
+    # New, position-aware path:
+    assert str(_extract_embedded_ipv4(ipaddress.ip_address(addr))) == "169.254.169.254"
+    assert is_private_ip(addr) is True
+
+
+def test_nat64_well_known_96_unchanged():
+    # /96 well-known carries IPv4 in the low 32 bits; behaviour must be preserved.
+    assert is_private_ip("64:ff9b::a9fe:a9fe") is True
+    assert is_private_ip("64:ff9b::808:808") is False  # public stays reachable
+
+
+@pytest.mark.parametrize("prefix_len,octets", [
+    (32, (4, 5, 6, 7)),
+    (40, (5, 6, 7, 9)),
+    (48, (6, 7, 9, 10)),
+    (56, (7, 9, 10, 11)),
+    (64, (9, 10, 11, 12)),
+    (96, (12, 13, 14, 15)),
+])
+def test_nat64_position_aware_all_prefix_lengths(prefix_len, octets):
+    raw = bytearray(16)
+    for octet_pos, value in zip(octets, (10, 1, 2, 3)):
+        raw[octet_pos] = value
+    assert str(_nat64_embedded_ipv4(bytes(raw), prefix_len)) == "10.1.2.3"
+
+
+def test_nat64_unsupported_prefix_len_returns_none():
+    assert _nat64_embedded_ipv4(bytes(16), 80) is None
+
+
+# ---------------------------------------------------------------------------
+# FLYA-23 #1 — DNS-rebinding / validate-then-use TOCTOU on the connect path
+# ---------------------------------------------------------------------------
+
+from core.safe_http import _check_addrs_safe  # noqa: E402
+
+
+def test_rebind_blocked_at_connect_time():
+    """Validation sees a public IP; the host rebinds to a metadata IP before the
+    connect-time resolution. The connect-path check must reject it.
+
+    Fails against old code (no connect-time re-validation; the guard returned a
+    URL string and the client re-resolved freely). Passes against new.
+    """
+    host = "rebind.attacker.example"
+    # 1) validation-time resolution: public -> allowed
+    _check_addrs_safe(host, ["93.184.216.34"], allow_private=False, allowed_hosts=None)
+    # 2) connect-time resolution after rebind: metadata -> must raise
+    with pytest.raises(SSRFError):
+        _check_addrs_safe(host, ["169.254.169.254"], allow_private=False, allowed_hosts=None)
+
+
+def test_connect_check_fails_closed_on_mixed_addrs():
+    # A single private address in a multi-answer result rejects the whole resolve.
+    with pytest.raises(SSRFError):
+        _check_addrs_safe("h", ["8.8.8.8", "10.0.0.5"], allow_private=False, allowed_hosts=None)
+
+
+def test_connect_check_blocks_transition_addr():
+    # IPv6 transition encodings are caught at connect time too.
+    with pytest.raises(SSRFError):
+        _check_addrs_safe("h", ["64:ff9b::a9fe:a9fe"], allow_private=False, allowed_hosts=None)
+
+
+def test_connect_check_allow_private_bypass():
+    # Dev / self-hosted escape hatch must still work.
+    _check_addrs_safe("h", ["127.0.0.1"], allow_private=True, allowed_hosts=None)
+
+
+def test_connect_check_allowlist_bypass():
+    _check_addrs_safe("internal.corp", ["10.0.0.1"], allow_private=False,
+                      allowed_hosts=["internal.corp"])
+    _check_addrs_safe("api.corp.com", ["10.0.0.1"], allow_private=False,
+                      allowed_hosts=["*.corp.com"])
+
+
+def test_connect_check_public_passes():
+    # No raise for a clean public resolution.
+    _check_addrs_safe("good.example", ["93.184.216.34"], allow_private=False,
+                      allowed_hosts=None)
+
+
+def test_ssrf_guarded_resolver_blocks_private():
+    """End-to-end resolver test (requires aiohttp). A base resolver returning a
+    private IP must make SSRFGuardedResolver.resolve raise SSRFError."""
+    pytest.importorskip("aiohttp")
+    import asyncio
+    from core.safe_http import _get_resolver_cls
+
+    class FakeBase:
+        def __init__(self, host_ip):
+            self._host_ip = host_ip
+
+        async def resolve(self, host, port=0, family=0):
+            return [{
+                "hostname": host, "host": self._host_ip, "port": port,
+                "family": family, "proto": 0, "flags": 0,
+            }]
+
+        async def close(self):
+            pass
+
+    resolver_cls = _get_resolver_cls()
+    resolver = resolver_cls(allow_private=False, allowed_hosts=None,
+                            base=FakeBase("169.254.169.254"))
+
+    async def go():
+        with pytest.raises(SSRFError):
+            await resolver.resolve("rebind.attacker.example", 443)
+        await resolver.close()
+
+    asyncio.run(go())


### PR DESCRIPTION
## Problem

Three files in `flyto-core` used `str | None` / `int | None` union type syntax (PEP 604), which requires Python 3.10+. This caused a `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` at module import time on Python 3.9.

This broke `flyto-pro` CI on Python 3.9 since `flyto-pro` imports `core.modules.registry.ModuleRegistry` which transitively imports `stability.py`.

## Fix

Added `from __future__ import annotations` (PEP 563) to the three affected files:
- `core/modules/types/stability.py`
- `core/modules/atomic/ai/embed.py`
- `core/modules/atomic/ai/vision_analyze.py`

PEP 563 makes annotations lazy (string literals), so `str | None` syntax works on Python 3.9+.

## Verification

After this fix, `flyto-pro` tests pass on Python 3.9:
- `test_executor_bdd.py::TestBddExe01SimpleModeSuccess::test_bdd_exe01_single_step_real_module` ✅

## Version bump

2.26.4 → 2.26.5 (patch release, backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)