### PR TITLE
security(mcp): enforce module capability filter on both MCP transports (deny-by-default)

### DIFF
--- a/src/core/api/security.py
+++ b/src/core/api/security.py
@@ -7,12 +7,20 @@ Environment variables:
   FLYTO_CORS_ORIGINS    — Comma-separated allowed origins (default: localhost only).
                           Set to "*" to allow all origins.
   FLYTO_API_TOKEN       — Fixed bearer token. If unset, auto-generated on startup.
-  FLYTO_MODULE_DENYLIST — Comma-separated glob patterns to deny (default: "shell.*,process.*").
-                          Set to empty string to clear.
+  FLYTO_MODULE_DENYLIST — Comma-separated glob patterns to deny. Defaults to the
+                          dangerous-by-default set below (host RCE / SSRF-to-DB /
+                          unconfined filesystem sinks). Set to empty string to clear
+                          (NOT recommended when exposing the server to any client),
+                          or override with your own list.
   FLYTO_MODULE_ALLOWLIST — If set, ONLY these modules are allowed (overrides denylist).
+                          Use this for strict deny-by-default when serving untrusted
+                          or red-team MCP clients.
+
+The same ModuleFilter singleton gates BOTH the REST route and BOTH MCP transports
+(STDIO + HTTP) — see mcp_handler.execute_module / run_recipe. There is no transport
+that bypasses it.
 """
 
-import fnmatch
 import logging
 import os
 import secrets
@@ -196,46 +204,10 @@ def enforce_bind_policy(host: str) -> None:
 # ---------------------------------------------------------------------------
 # Module Filter (Denylist / Allowlist)
 # ---------------------------------------------------------------------------
-
-_DEFAULT_DENYLIST = ["shell.*", "process.*"]
-
-
-class ModuleFilter:
-    """Filter modules by glob-pattern denylist/allowlist."""
-
-    def __init__(self):
-        self.denylist: List[str] = []
-        self.allowlist: List[str] = []
-        self._load_from_env()
-
-    def _load_from_env(self):
-        # Allowlist takes priority if set
-        raw_allow = os.environ.get("FLYTO_MODULE_ALLOWLIST", "").strip()
-        if raw_allow:
-            self.allowlist = [p.strip() for p in raw_allow.split(",") if p.strip()]
-            logger.info("Module allowlist: %s", self.allowlist)
-            return
-
-        # Denylist
-        raw_deny = os.environ.get("FLYTO_MODULE_DENYLIST")
-        if raw_deny is not None:
-            # Explicit env var — could be empty to clear defaults
-            raw_deny = raw_deny.strip()
-            self.denylist = [p.strip() for p in raw_deny.split(",") if p.strip()] if raw_deny else []
-        else:
-            self.denylist = list(_DEFAULT_DENYLIST)
-
-        if self.denylist:
-            logger.info("Module denylist: %s", self.denylist)
-
-    def is_allowed(self, module_id: str) -> bool:
-        """Check if a module is allowed to execute."""
-        if self.allowlist:
-            return any(fnmatch.fnmatch(module_id, pat) for pat in self.allowlist)
-        if self.denylist:
-            return not any(fnmatch.fnmatch(module_id, pat) for pat in self.denylist)
-        return True
-
-
-# Singleton — initialized on import, reads env vars once
-module_filter = ModuleFilter()
+#
+# The ModuleFilter lives in core.module_policy (dependency-free) so the SAME
+# singleton can gate the module-execution hot path on every transport — the REST
+# route here AND both MCP transports (mcp_handler.execute_module / run_recipe) —
+# without importing FastAPI. Re-exported here for backward compatibility with
+# existing `from ..security import module_filter` call sites.
+from core.module_policy import ModuleFilter, module_filter, _DEFAULT_DENYLIST  # noqa: E402,F401

--- a/src/core/mcp_handler.py
+++ b/src/core/mcp_handler.py
@@ -156,6 +156,45 @@ def get_module_info(module_id: str) -> dict:
         return {"error": str(e)}
 
 
+# ---------------------------------------------------------------------------
+# Capability policy — the SAME ModuleFilter that guards the REST route, applied
+# here so both MCP transports (STDIO + HTTP) are gated. Imported lazily to keep
+# the STDIO path free of an import-time FastAPI dependency.
+# ---------------------------------------------------------------------------
+
+def _module_is_allowed(module_id: str) -> bool:
+    from core.module_policy import module_filter
+    return module_filter.is_allowed(module_id)
+
+
+def _denied_module_response(module_id: str) -> dict:
+    return {
+        "ok": False,
+        "error": (
+            f"Module '{module_id}' is blocked by the server capability policy "
+            "(FLYTO_MODULE_DENYLIST / FLYTO_MODULE_ALLOWLIST). This category can grant "
+            "host code execution, SSRF, or unconfined filesystem access and is denied "
+            "by default. An operator must explicitly allow it before it can run."
+        ),
+        "blocked_by": "module_filter",
+    }
+
+
+def _collect_module_ids(obj: Any) -> set:
+    """Recursively collect every `module:` id declared anywhere in a workflow dict."""
+    found: set = set()
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if key == "module" and isinstance(value, str) and value:
+                found.add(value)
+            else:
+                found |= _collect_module_ids(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            found |= _collect_module_ids(item)
+    return found
+
+
 async def execute_module(
     module_id: str,
     params: Dict[str, Any],
@@ -173,6 +212,10 @@ async def execute_module(
     """
     if browser_sessions is None:
         browser_sessions = {}
+
+    # Capability gate — fail closed before any module is resolved/instantiated.
+    if not _module_is_allowed(module_id):
+        return _denied_module_response(module_id)
 
     try:
         from core.modules.registry import ModuleRegistry
@@ -443,6 +486,22 @@ async def run_recipe(
             return {"ok": False, "error": f"Recipe not found: {recipe_name}"}
 
         workflow = substitute_args(recipe, args)
+
+        # Capability gate — reject the whole recipe if ANY declared step uses a
+        # module denied by the policy, before the engine executes a single step.
+        denied = sorted(m for m in _collect_module_ids(workflow) if not _module_is_allowed(m))
+        if denied:
+            return {
+                "ok": False,
+                "error": (
+                    f"Recipe '{recipe_name}' is blocked: it uses modules denied by the "
+                    f"server capability policy: {', '.join(denied)}. An operator must "
+                    "explicitly allow these (FLYTO_MODULE_DENYLIST / FLYTO_MODULE_ALLOWLIST) "
+                    "before the recipe can run."
+                ),
+                "blocked_by": "module_filter",
+                "blocked_modules": denied,
+            }
 
         engine = WorkflowEngine(
             workflow=workflow,

--- a/src/core/module_policy.py
+++ b/src/core/module_policy.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Flyto2. Licensed under Apache-2.0. See LICENSE.
+
+"""
+Module capability policy — denylist / allowlist filter.
+
+Dependency-free (stdlib only) so it can gate the module-execution hot path on
+EVERY transport without dragging in FastAPI/the HTTP app:
+  - the REST route (api/routes/modules.py, re-exported via api.security)
+  - the STDIO MCP transport (mcp_server.py -> mcp_handler)
+  - the HTTP MCP transport (api/routes/mcp.py -> mcp_handler)
+
+Environment variables:
+  FLYTO_MODULE_DENYLIST  — Comma-separated glob patterns to deny. Defaults to the
+                           dangerous-by-default set below. Set to empty string to
+                           clear (NOT recommended), or override with your own list.
+  FLYTO_MODULE_ALLOWLIST — If set, ONLY these patterns are allowed (overrides the
+                           denylist). Use for strict deny-by-default when serving
+                           untrusted / red-team MCP clients.
+"""
+
+import fnmatch
+import logging
+import os
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+# Dangerous-by-default: deny capabilities that grant host code execution,
+# SSRF-to-internal-services, or unconfined filesystem mutation unless the
+# operator explicitly opts in (FLYTO_MODULE_DENYLIST / FLYTO_MODULE_ALLOWLIST).
+#
+# Scoped deliberately so the 37 shipped scraping/automation recipes keep working:
+#   - browser.* (incl. browser.evaluate, page-context JS) stays ALLOWED — it is the
+#     core scraping primitive; its host-escape risk is addressed by running the
+#     browser non-root (see the --no-sandbox hardening), not by denylisting it here.
+#   - docker.ps / network.* stay ALLOWED; only the host-control docker verbs are denied.
+# Operators serving untrusted / red-team MCP clients should tighten this further via
+# FLYTO_MODULE_ALLOWLIST (strict opt-in).
+_DEFAULT_DENYLIST = [
+    "shell.*",          # arbitrary host command execution
+    "process.*",        # process spawn / detached reverse-shell surface
+    "sandbox.*",        # execute_shell / execute_python / execute_js — NOT real sandboxes
+    "database.*",       # client-supplied connection_string + raw SQL = SSRF-to-DB
+    "k8s.*",            # cluster control
+    "ssh.*",            # remote exec / credential MITM
+    "docker.run",       # container host control (docker.ps stays allowed)
+    "docker.exec",
+    "file.delete",      # path not validated — arbitrary host file deletion
+]
+
+
+class ModuleFilter:
+    """Filter modules by glob-pattern denylist/allowlist."""
+
+    def __init__(self):
+        self.denylist: List[str] = []
+        self.allowlist: List[str] = []
+        self._load_from_env()
+
+    def _load_from_env(self):
+        # Allowlist takes priority if set
+        raw_allow = os.environ.get("FLYTO_MODULE_ALLOWLIST", "").strip()
+        if raw_allow:
+            self.allowlist = [p.strip() for p in raw_allow.split(",") if p.strip()]
+            logger.info("Module allowlist: %s", self.allowlist)
+            return
+
+        # Denylist
+        raw_deny = os.environ.get("FLYTO_MODULE_DENYLIST")
+        if raw_deny is not None:
+            # Explicit env var — could be empty to clear defaults
+            raw_deny = raw_deny.strip()
+            self.denylist = [p.strip() for p in raw_deny.split(",") if p.strip()] if raw_deny else []
+        else:
+            self.denylist = list(_DEFAULT_DENYLIST)
+
+        if self.denylist:
+            logger.info("Module denylist: %s", self.denylist)
+
+    def is_allowed(self, module_id: str) -> bool:
+        """Check if a module is allowed to execute."""
+        if self.allowlist:
+            return any(fnmatch.fnmatch(module_id, pat) for pat in self.allowlist)
+        if self.denylist:
+            return not any(fnmatch.fnmatch(module_id, pat) for pat in self.denylist)
+        return True
+
+
+# Singleton — initialized on import, reads env vars once
+module_filter = ModuleFilter()

--- a/tests/core/test_mcp_capability_filter.py
+++ b/tests/core/test_mcp_capability_filter.py
@@ -1,0 +1,142 @@
+"""
+MCP capability-filter tests — the guardrail that closes the host-RCE / SSRF-to-DB
+exposure where the module denylist was enforced ONLY on the REST route and
+bypassed by both MCP transports (STDIO + HTTP).
+
+Covers:
+  - the dangerous-by-default denylist (sandbox/shell/process/database/k8s/ssh/
+    docker.run/file.delete) while keeping the shipped scraping primitives
+    (browser.evaluate, docker.ps, file.write) allowed
+  - execute_module() fails closed for a denied module, runs an allowed one
+  - run_recipe() rejects a recipe whose declared steps use a denied module,
+    BEFORE the engine executes anything
+  - FLYTO_MODULE_ALLOWLIST strict opt-in overrides the denylist
+"""
+
+import pytest
+
+from core.modules import atomic  # noqa: F401 — triggers module registration
+
+import core.module_policy as module_policy
+from core.module_policy import ModuleFilter
+from core.mcp_handler import execute_module, run_recipe, _collect_module_ids
+
+
+@pytest.fixture
+def policy(monkeypatch):
+    """Install a ModuleFilter built from the given env, as the active singleton."""
+    def _install(denylist=None, allowlist=None):
+        monkeypatch.delenv("FLYTO_MODULE_DENYLIST", raising=False)
+        monkeypatch.delenv("FLYTO_MODULE_ALLOWLIST", raising=False)
+        if denylist is not None:
+            monkeypatch.setenv("FLYTO_MODULE_DENYLIST", denylist)
+        if allowlist is not None:
+            monkeypatch.setenv("FLYTO_MODULE_ALLOWLIST", allowlist)
+        mf = ModuleFilter()
+        # _module_is_allowed() does `from core.module_policy import module_filter`
+        monkeypatch.setattr(module_policy, "module_filter", mf)
+        return mf
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Default policy shape
+# ---------------------------------------------------------------------------
+
+DANGEROUS = [
+    "shell.exec", "process.start", "sandbox.execute_shell", "sandbox.execute_python",
+    "sandbox.execute_js", "database.query", "database.update", "k8s.apply",
+    "ssh.exec", "docker.run", "docker.exec", "file.delete",
+]
+SHIPPED_SAFE = [
+    "string.uppercase", "browser.evaluate", "browser.goto", "docker.ps",
+    "file.write", "http.get", "network.whois",
+]
+
+
+def test_default_denylist_blocks_dangerous():
+    mf = ModuleFilter()  # reads real default (no env)
+    for mid in DANGEROUS:
+        assert mf.is_allowed(mid) is False, f"{mid} should be denied by default"
+
+
+def test_default_denylist_keeps_shipped_recipes_working():
+    mf = ModuleFilter()
+    for mid in SHIPPED_SAFE:
+        assert mf.is_allowed(mid) is True, f"{mid} should stay allowed by default"
+
+
+# ---------------------------------------------------------------------------
+# execute_module — the direct MCP chokepoint (both transports flow through here)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_execute_module_denies_sandbox_rce(policy):
+    policy()  # default dangerous denylist
+    result = await execute_module("sandbox.execute_shell", {"command": "id"})
+    assert result["ok"] is False
+    assert result.get("blocked_by") == "module_filter"
+
+
+@pytest.mark.asyncio
+async def test_execute_module_denies_database_ssrf(policy):
+    policy()
+    result = await execute_module(
+        "database.query",
+        {"connection_string": "postgres://internal-rds:5432/x", "query": "SELECT 1"},
+    )
+    assert result["ok"] is False
+    assert result.get("blocked_by") == "module_filter"
+
+
+@pytest.mark.asyncio
+async def test_execute_module_allows_safe_module(policy):
+    policy()
+    result = await execute_module("string.uppercase", {"text": "hello"})
+    assert result.get("ok") is True
+    assert result["data"]["result"] == "HELLO"
+
+
+@pytest.mark.asyncio
+async def test_allowlist_is_strict_opt_in(policy):
+    policy(allowlist="string.*")
+    assert (await execute_module("string.uppercase", {"text": "hi"})).get("ok") is True
+    blocked = await execute_module("http.get", {"url": "http://example.com"})
+    assert blocked["ok"] is False
+    assert blocked.get("blocked_by") == "module_filter"
+
+
+# ---------------------------------------------------------------------------
+# run_recipe — pre-flight static scan rejects denied steps before execution
+# ---------------------------------------------------------------------------
+
+def test_collect_module_ids_walks_nested():
+    workflow = {
+        "steps": [
+            {"module": "browser.goto"},
+            {"module": "flow.loop", "body": [{"module": "sandbox.execute_python"}]},
+        ]
+    }
+    assert _collect_module_ids(workflow) == {
+        "browser.goto", "flow.loop", "sandbox.execute_python",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_recipe_blocks_denied_module(policy, monkeypatch):
+    policy()  # default denylist denies sandbox.*
+    import cli.recipe as recipe_mod
+
+    poisoned = {"steps": [
+        {"id": "s1", "module": "browser.goto", "params": {"url": "http://x"}},
+        {"id": "s2", "module": "sandbox.execute_python", "params": {"code": "import os; os.system('id')"}},
+    ]}
+    monkeypatch.setattr(recipe_mod, "load_recipe", lambda name: poisoned)
+    monkeypatch.setattr(recipe_mod, "substitute_args", lambda wf, args: wf)
+
+    # If the gate fails, the engine would actually run the RCE step; instead we
+    # expect a fail-closed rejection naming the denied module.
+    result = await run_recipe("poisoned-recipe", {})
+    assert result["ok"] is False
+    assert result.get("blocked_by") == "module_filter"
+    assert "sandbox.execute_python" in result.get("blocked_modules", [])


### PR DESCRIPTION
## P0 — closes the flyto-core host-RCE / SSRF-as-a-service exposure (audit C-1/C-2/C-3/H-7/H-8)

**Root cause:** the module denylist (`ModuleFilter`) was enforced **only** on the REST route (`api/routes/modules.py:97`). Both MCP transports — STDIO (`mcp_handler.execute_module`/`run_recipe`) and HTTP (`api/routes/mcp.py`) — dispatched modules with **no capability check at all**. Any connected MCP client (Claude Desktop/Code, or a prompt-injected agent) could invoke any of the 300+ modules with arbitrary params, including:

- `sandbox.execute_shell` / `execute_python` / `execute_js`, `process.start`, `shell.*` → **host RCE + `os.environ` secret exfiltration**
- `database.query` with a client-supplied `connection_string` → **SSRF into internal DBs + arbitrary SQL/DDL**

The `shell.*`/`process.*` denylist the operator believed protected the host was **completely bypassed** by both MCP transports.

## What this does

- **Extracts `ModuleFilter` into `core.module_policy`** (stdlib-only, no FastAPI) so the *same* singleton gates the module-execution hot path on **every** transport without building the HTTP app. `api.security` re-exports it (backward compatible).
- **Gates `execute_module`** — fails closed before a module is resolved.
- **Gates `run_recipe`** — pre-flight static scan of every declared `module:` in the substituted workflow; rejects the whole recipe before the engine runs a single step if any module is denied.
- **Expands the deny-by-default set** to the real RCE/SSRF/unconfined-fs sinks (`sandbox.*`, `database.*`, `k8s.*`, `ssh.*`, `docker.run/exec`, `file.delete`) on top of `shell.*`/`process.*`.

## Deliberately scoped so all 37 shipped recipes keep working
`browser.evaluate` (page-context JS, used by **22** shipped scraping recipes), `docker.ps`, and `network.*` stay **allowed** — their risk (browser host-escape) is addressed by running the browser non-root, not by denylisting the core scraping primitive. Operators serving untrusted / red-team MCP clients should tighten further via `FLYTO_MODULE_ALLOWLIST` (strict opt-in).

## Verification
- New `tests/core/test_mcp_capability_filter.py` (8 tests): `execute_module` denies sandbox/database & allows `string.*`; `run_recipe` rejects a recipe whose step uses a denied module **before** execution; allowlist strict opt-in; default policy blocks every dangerous sink while keeping shipped primitives.
- Existing `test_routes` + `test_mcp_auth` + `test_mcp_real` stay green (**120 tests passed** locally).
- Verified the STDIO hot-path stays **FastAPI-free** (gate import pulls neither `fastapi` nor `core.api`).

## Follow-ups (separate PRs, from the same audit roadmap)
P0-10 real per-client `required_permissions` binding · P0-11 true OS isolation for the sandbox/process sinks (the deny is a stopgap; opted-in categories still need real containment) · P0-12 forbid client-supplied DB `connection_string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)