### PR TITLE
security(modules): scrub sandbox env + confine file.delete + block client DB DSN (P0-11/P0-12)

### DIFF
--- a/src/core/modules/atomic/database/query.py
+++ b/src/core/modules/atomic/database/query.py
@@ -101,7 +101,17 @@ async def database_query(context: Dict[str, Any]) -> Dict[str, Any]:
     query = params['query']
     query_params = params.get('params', [])
     db_type = params.get('database_type', 'postgresql')
-    connection_string = params.get('connection_string') or os.getenv('DATABASE_URL')
+    # SECURITY: a caller-supplied connection_string lets an untrusted client point
+    # the query at ANY host (e.g. postgres://internal-rds:5432) — SSRF-to-DB plus
+    # arbitrary SQL/DDL. Forbid client DSNs by default; require a server-configured
+    # DATABASE_URL. Set FLYTO_ALLOW_CLIENT_DB_DSN=1 to opt back in for trusted use.
+    client_dsn = params.get('connection_string')
+    if client_dsn and os.environ.get('FLYTO_ALLOW_CLIENT_DB_DSN', '').strip().lower() not in ('1', 'true', 'yes', 'on'):
+        raise ValueError(
+            "client-supplied connection_string is disabled; configure DATABASE_URL "
+            "server-side (set FLYTO_ALLOW_CLIENT_DB_DSN=1 to override)"
+        )
+    connection_string = client_dsn or os.getenv('DATABASE_URL')
     fetch_mode = params.get('fetch', 'all')
 
     # Validate query (basic security check)

--- a/src/core/modules/atomic/file/delete.py
+++ b/src/core/modules/atomic/file/delete.py
@@ -11,6 +11,7 @@ from typing import Any, Dict
 from ...base import BaseModule
 from ...registry import register_module
 from ...schema import compose, presets
+from ....utils import validate_path_with_env_config, PathTraversalError
 
 
 @register_module(
@@ -82,9 +83,16 @@ class FileDeleteModule(BaseModule):
             raise ValueError("file_path is required")
 
     async def execute(self) -> Any:
+        # SECURITY: confine deletion to the configured workspace, matching
+        # file.read/write/edit. Without this, file.delete accepted any absolute
+        # path (e.g. /etc/passwd) — arbitrary host file deletion.
         try:
-            if os.path.exists(self.file_path):
-                os.remove(self.file_path)
+            safe_path = validate_path_with_env_config(self.file_path)
+        except PathTraversalError as e:
+            raise RuntimeError(f"Refusing to delete outside the allowed path: {e}")
+        try:
+            if os.path.exists(safe_path):
+                os.remove(safe_path)
                 return {
                     "deleted": True,
                     "file_path": self.file_path

--- a/src/core/modules/atomic/sandbox/execute_python.py
+++ b/src/core/modules/atomic/sandbox/execute_python.py
@@ -17,6 +17,7 @@ from ...schema import compose
 from ...schema.builders import field
 from ...schema.constants import FieldGroup
 from ...errors import ValidationError, ModuleError
+from .safe_env import build_sandbox_env
 
 logger = logging.getLogger(__name__)
 
@@ -151,10 +152,13 @@ async def sandbox_execute_python(context: Dict[str, Any]) -> Dict[str, Any]:
 
         start_time = time.monotonic()
 
+        # Run with a scrubbed environment so attacker code cannot read host
+        # secrets from os.environ. Set FLYTO_SANDBOX_INHERIT_ENV=1 to override.
         proc = await asyncio.create_subprocess_exec(
             sys.executable, tmp_path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=build_sandbox_env(params.get('env')),
         )
 
         try:

--- a/src/core/modules/atomic/sandbox/execute_shell.py
+++ b/src/core/modules/atomic/sandbox/execute_shell.py
@@ -15,6 +15,7 @@ from ...schema import compose
 from ...schema.builders import field
 from ...schema.constants import FieldGroup
 from ...errors import ValidationError, ModuleError
+from .safe_env import build_sandbox_env
 
 logger = logging.getLogger(__name__)
 
@@ -150,12 +151,11 @@ async def sandbox_execute_shell(context: Dict[str, Any]) -> Dict[str, Any]:
             field="working_dir",
         )
 
-    # Build environment: inherit current env + merge extra vars
-    env = None
-    if extra_env:
-        env = dict(os.environ)
-        for k, v in extra_env.items():
-            env[str(k)] = str(v)
+    # Build environment from a scrubbed allowlist (PATH/HOME/locale/...) plus any
+    # caller-supplied vars — NOT the full parent env, so a sandboxed command
+    # cannot read host secrets (API keys, tokens, DATABASE_URL) out of os.environ.
+    # Set FLYTO_SANDBOX_INHERIT_ENV=1 to restore full inheritance.
+    env = build_sandbox_env(extra_env)
 
     start_time = time.monotonic()
 

--- a/src/core/modules/atomic/sandbox/safe_env.py
+++ b/src/core/modules/atomic/sandbox/safe_env.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Flyto2. Licensed under Apache-2.0. See LICENSE.
+
+"""Scrubbed environment for sandbox subprocesses.
+
+sandbox.execute_shell / execute_python spawn a child process. Inheriting the
+full parent environment hands every host secret (API keys, tokens, DATABASE_URL,
+cloud credentials) to attacker-controlled code, so the child can read and
+exfiltrate them. This module builds a minimal environment containing only
+non-sensitive, execution-relevant variables.
+
+This is defense-in-depth: the modules are denied by default at the MCP
+capability layer; this ensures that even when an operator deliberately opts them
+in, the executed code cannot trivially harvest host secrets via os.environ.
+
+Override with FLYTO_SANDBOX_INHERIT_ENV=1 to restore full inheritance (NOT
+recommended when serving untrusted / red-team clients).
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+# Variables safe to pass through. Deliberately excludes anything that commonly
+# carries credentials. PATH is included so interpreters/tools resolve.
+_SAFE_ENV_PASSTHROUGH = (
+    "PATH", "HOME", "LANG", "LANGUAGE", "LC_ALL", "LC_CTYPE",
+    "TERM", "TMPDIR", "TEMP", "TMP", "TZ", "PWD", "SHELL",
+)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def inherit_full_env() -> bool:
+    return os.environ.get("FLYTO_SANDBOX_INHERIT_ENV", "").strip().lower() in _TRUTHY
+
+
+def build_sandbox_env(extra_env: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    """Return the environment for a sandbox subprocess.
+
+    By default: only the non-sensitive passthrough allowlist, plus any caller
+    supplied extra_env (which the caller is explicitly choosing to inject).
+    With FLYTO_SANDBOX_INHERIT_ENV truthy: the full parent environment.
+    """
+    if inherit_full_env():
+        env = dict(os.environ)
+    else:
+        env = {k: os.environ[k] for k in _SAFE_ENV_PASSTHROUGH if k in os.environ}
+    for k, v in (extra_env or {}).items():
+        env[str(k)] = str(v)
+    return env

--- a/tests/core/test_exec_hardening.py
+++ b/tests/core/test_exec_hardening.py
@@ -1,0 +1,78 @@
+"""Execution-hardening tests (defense-in-depth for the sandbox/file/database sinks):
+  - sandbox subprocesses run with a scrubbed env (no host secret leakage)
+  - file.delete is confined to the configured sandbox dir (no arbitrary deletion)
+  - database.query rejects a client-supplied connection_string (SSRF-to-DB) by default
+"""
+
+import pytest
+
+from core.modules import atomic  # noqa: F401 — registers modules
+from core.modules.atomic.sandbox.safe_env import build_sandbox_env
+from core.modules.atomic.file.delete import FileDeleteModule
+from core.mcp_handler import execute_module
+
+
+class TestBuildSandboxEnv:
+    def test_scrubs_secrets_keeps_path(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+        monkeypatch.setenv("DATABASE_URL", "postgres://host/db")
+        monkeypatch.delenv("FLYTO_SANDBOX_INHERIT_ENV", raising=False)
+        env = build_sandbox_env()
+        assert env.get("PATH") == "/usr/bin"
+        assert "OPENAI_API_KEY" not in env
+        assert "DATABASE_URL" not in env
+
+    def test_merges_caller_extra(self, monkeypatch):
+        monkeypatch.delenv("FLYTO_SANDBOX_INHERIT_ENV", raising=False)
+        env = build_sandbox_env({"FOO": "bar"})
+        assert env["FOO"] == "bar"
+
+    def test_inherit_flag_restores_full_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+        monkeypatch.setenv("FLYTO_SANDBOX_INHERIT_ENV", "1")
+        env = build_sandbox_env()
+        assert env.get("OPENAI_API_KEY") == "sk-secret"
+
+
+class TestFileDeleteConfinement:
+    @pytest.mark.asyncio
+    async def test_refuses_outside_sandbox(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("FLYTO_SANDBOX_DIR", str(tmp_path))
+        monkeypatch.delenv("FLYTO_ALLOW_ABSOLUTE_PATHS", raising=False)
+        mod = FileDeleteModule({"file_path": "/etc/passwd"}, {})
+        with pytest.raises(RuntimeError, match="Refusing to delete outside"):
+            await mod.execute()
+
+    @pytest.mark.asyncio
+    async def test_deletes_inside_sandbox(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("FLYTO_SANDBOX_DIR", str(tmp_path))
+        f = tmp_path / "x.txt"
+        f.write_text("hi")
+        mod = FileDeleteModule({"file_path": str(f)}, {})
+        result = await mod.execute()
+        assert result["deleted"] is True
+        assert not f.exists()
+
+
+@pytest.mark.asyncio
+class TestDatabaseDSNGuard:
+    async def test_client_dsn_rejected_by_default(self, monkeypatch):
+        monkeypatch.delenv("FLYTO_ALLOW_CLIENT_DB_DSN", raising=False)
+        res = await execute_module("database.query", {
+            "query": "SELECT 1",
+            "connection_string": "postgres://internal-rds:5432/x",
+        })
+        assert res.get("ok") is False
+        assert "connection_string is disabled" in res.get("error", "")
+
+    async def test_client_dsn_allowed_with_flag(self, monkeypatch):
+        monkeypatch.setenv("FLYTO_ALLOW_CLIENT_DB_DSN", "1")
+        # With the flag the guard must NOT fire; the call then fails later trying
+        # to actually connect — assert only it is not the guard's rejection.
+        res = await execute_module("database.query", {
+            "query": "SELECT 1",
+            "connection_string": "postgres://127.0.0.1:1/x",
+            "database_type": "postgresql",
+        })
+        assert "connection_string is disabled" not in res.get("error", "")


### PR DESCRIPTION
Module-level **defense-in-depth** for the high-risk execution sinks. Independent of #29 (the MCP capability filter): #29 denies these by default; this PR ensures that even when an operator *deliberately opts them in*, they can't trivially compromise the host.

### `sandbox.execute_shell` / `execute_python` — env scrubbing (P0-11)
Subprocesses inherited the **full `os.environ`**, handing attacker code every host secret (API keys, tokens, `DATABASE_URL`) to read and exfiltrate. Now they run with a **scrubbed allowlist** (`PATH`/`HOME`/locale/… + caller-supplied vars) via the new shared `sandbox/safe_env.build_sandbox_env`. `FLYTO_SANDBOX_INHERIT_ENV=1` restores full inheritance for trusted use.

### `file.delete` — path confinement (P0-11)
Accepted any absolute path (e.g. `/etc/passwd`) → **arbitrary host file deletion**. Now validated with `validate_path_with_env_config` — the exact guard `file.read`/`write`/`edit` already use.

### `database.query` — block client DSN (P0-12)
A caller-supplied `connection_string` let an untrusted client point the query at **any** host (`postgres://internal-rds:5432`) = SSRF-to-DB + arbitrary SQL/DDL. Now rejected by default; require a server-configured `DATABASE_URL`. `FLYTO_ALLOW_CLIENT_DB_DSN=1` opts back in.

## Verification
`tests/core/test_exec_hardening.py`: env scrub hides secrets / keeps PATH / merges extra / inherit-flag restores; `file.delete` refuses outside the sandbox dir and still deletes inside; `database.query` rejects the client DSN by default and lets it through with the flag. **239 relevant module tests stay green** (3 unrelated agent suites fail to collect on `openai` not installed — pre-existing).

## Honest scope
These are **stopgaps, not real OS isolation**. Genuinely containing `sandbox.*`/`process.*` needs a separate unprivileged uid + seccomp/nsjail/container + no-network — a deployment-level follow-up. This PR removes the cheapest exfiltration/escalation paths now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)