### PR TITLE
security(trace): redact credentials in trace + checkpoint artifacts (P1-5)

### DIFF
--- a/src/cli/recipe.py
+++ b/src/cli/recipe.py
@@ -6,12 +6,15 @@ Recipes are YAML workflow templates with named arguments.
 """
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
+
+from core.engine.redaction import redact_for_persistence
 
 from .config import Colors
 
@@ -308,11 +311,16 @@ def run_recipe(recipe_name: str, raw_args: List[str]) -> int:
             'hint': _step_hint(s),
         }
 
-    # Prepare run state directory for replay support
+    # Prepare run state directory for replay support. Lock it to the owner —
+    # run artifacts carry resolved params/context that may include credentials.
     run_dir = RUNS_DIR / 'latest'
     run_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(run_dir, 0o700)
+    except OSError:
+        pass
     _save_json(run_dir / 'workflow.json', workflow)
-    _save_json(run_dir / 'params.json', params)
+    _save_json(run_dir / 'params.json', redact_for_persistence(params))
 
     # Real-time checkpoint callback: prints each step + saves context snapshot
     completed_count = 0
@@ -425,10 +433,15 @@ def _print_output_files(args: Dict[str, str], engine) -> None:
 # ── Replay support helpers ─────────────────────────────────────────
 
 def _save_json(path: Path, data: Any) -> None:
-    """Save JSON, silently skip non-serializable data."""
+    """Save JSON, silently skip non-serializable data. Files are owner-only (0600)
+    since run artifacts may contain resolved credentials."""
     try:
         with open(path, 'w') as f:
             json.dump(data, f, indent=2, default=str)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
     except Exception:
         pass
 
@@ -452,8 +465,9 @@ def _save_checkpoint_snapshot(
         'step_index': step_index,
         'step_id': step_id,
         'status': status,
-        'context': clean_ctx,
-        'params': checkpoint_data.get('params', {}),
+        # SECURITY: redact credentials before they land in checkpoint_*.json.
+        'context': redact_for_persistence(clean_ctx),
+        'params': redact_for_persistence(checkpoint_data.get('params', {})),
     }
     _save_json(run_dir / f'checkpoint_{step_index:03d}_{step_id}.json', snapshot)
     # Also keep a "latest successful" pointer for easy replay

--- a/src/core/engine/trace.py
+++ b/src/core/engine/trace.py
@@ -118,13 +118,19 @@ class StepInput:
     itemCount: int = 0
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary."""
+        """Convert to dictionary.
+
+        SECURITY: redact credentials from params before the trace is serialized —
+        get_execution_trace() is returned to MCP/API clients and persisted, so a
+        recipe that carries a token/DSN must not echo it back in plaintext.
+        """
+        from .redaction import redact_for_persistence
         result = {
-            "params": self.params,
-            "paramsRaw": self.paramsRaw,
+            "params": redact_for_persistence(self.params),
+            "paramsRaw": redact_for_persistence(self.paramsRaw),
         }
         if self.items is not None:
-            result["items"] = self.items
+            result["items"] = redact_for_persistence(self.items)
             result["itemCount"] = self.itemCount
         return result
 

--- a/tests/core/test_trace_checkpoint_redaction.py
+++ b/tests/core/test_trace_checkpoint_redaction.py
@@ -1,0 +1,55 @@
+"""Credentials must be redacted from the execution trace (returned to clients)
+and from on-disk checkpoint/params artifacts (P1-5 follow-up to evidence redaction)."""
+
+import json
+import os
+import stat
+
+from core.engine.trace import StepInput
+
+
+class TestTraceRedaction:
+    def test_step_input_to_dict_redacts_params(self):
+        si = StepInput(
+            params={"url": "postgres://u:p4ssw0rd@db/app", "token": "sk-ABCDEFGHIJKLMNOPQRST"},
+            paramsRaw={"password": "hunter2"},
+        )
+        d = si.to_dict()
+        assert "p4ssw0rd" not in json.dumps(d["params"])
+        assert "sk-ABCDEFGHIJKLMNOPQRST" not in json.dumps(d["params"])
+        assert d["paramsRaw"]["password"] == "[REDACTED]"
+
+    def test_items_redacted(self):
+        si = StepInput(params={}, paramsRaw={}, items=[{"api_key": "x"}], itemCount=1)
+        d = si.to_dict()
+        assert d["items"][0]["api_key"] == "[REDACTED]"
+
+
+class TestCheckpointArtifacts:
+    def test_params_json_redacted_and_locked(self, tmp_path, monkeypatch):
+        import cli.recipe as recipe
+
+        monkeypatch.setattr(recipe, "RUNS_DIR", tmp_path)
+        run_dir = tmp_path / "latest"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        recipe._save_json(run_dir / "params.json", recipe.redact_for_persistence(
+            {"password": "topsecret", "note": "Bearer abcdef0123456789ABCD"}
+        ))
+        text = (run_dir / "params.json").read_text()
+        assert "topsecret" not in text
+        assert "abcdef0123456789ABCD" not in text
+        # owner-only file perms
+        mode = stat.S_IMODE(os.stat(run_dir / "params.json").st_mode)
+        assert mode == 0o600
+
+    def test_checkpoint_snapshot_redacts(self, tmp_path):
+        import cli.recipe as recipe
+
+        recipe._save_checkpoint_snapshot(
+            tmp_path, 1, "step1",
+            {"context": {"db_password": "s3cr3t", "x": "ok"}, "params": {"token": "t"}},
+            "success",
+        )
+        text = (tmp_path / "checkpoint_001_step1.json").read_text()
+        assert "s3cr3t" not in text
+        assert '"x": "ok"' in text  # non-secret preserved


### PR DESCRIPTION
Follow-up to #31 (stacked on `security/evidence-redaction`; retarget to `main` after it merges). The credential leak wasn't only `evidence.jsonl`:

- `trace.StepInput.to_dict()` returned `params`/`paramsRaw` verbatim, and the trace is handed back to MCP/API clients (`get_execution_trace`) **and** persisted.
- `cli/recipe.py` wrote `params.json` and `checkpoint_*.json` with resolved params + full context (login tokens, DB passwords) in **plaintext, world-readable**.

## Fix
- `StepInput.to_dict()` runs `params`/`paramsRaw`/`items` through `redact_for_persistence`.
- `params.json` and checkpoint snapshots are redacted before write; the run dir is `chmod 0700` and every `_save_json` file `0600` (owner-only).

## Verification
`tests/core/test_trace_checkpoint_redaction.py`: trace params/items redacted; `params.json` redacted + `0600`; checkpoint context/params redacted while non-secret keys preserved. **142** real recipe/trace/replay/executor tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)