### PR TITLE
security(plugin): pin installs to a trusted index + fail-closed mode (P2-5)

### DIFF
--- a/src/core/plugin/loader.py
+++ b/src/core/plugin/loader.py
@@ -19,6 +19,7 @@ Usage:
 import importlib
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -27,6 +28,12 @@ from datetime import datetime
 from importlib.metadata import distributions, entry_points
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
 
 from .manifest import PluginManifest, PluginModule, PluginStatus
 
@@ -307,7 +314,25 @@ class PluginLoader:
                 return False
             package_spec = f"{name}=={version}"
 
+        # SECURITY (supply chain): `pip install` runs the package's build backend
+        # — arbitrary code. The PLUGIN_PREFIX gate limits the *name*, not a hostile
+        # publisher of a legit-looking flyto-plugin-*. Two opt-in protections:
+        #   FLYTO_PLUGIN_INDEX_URL — install only from this (private/curated) index.
+        #   FLYTO_PLUGIN_REQUIRE_TRUSTED_INDEX=1 — refuse to install at all unless a
+        #     trusted index is configured (fail closed for hardened deployments).
+        index_url = os.environ.get("FLYTO_PLUGIN_INDEX_URL", "").strip()
+        if _env_truthy("FLYTO_PLUGIN_REQUIRE_TRUSTED_INDEX") and not index_url:
+            logger.error(
+                "Refusing to install %s: FLYTO_PLUGIN_REQUIRE_TRUSTED_INDEX is set "
+                "but no FLYTO_PLUGIN_INDEX_URL is configured (won't pull from public PyPI).",
+                name,
+            )
+            return False
+
         cmd = [sys.executable, "-m", "pip", "install", package_spec]
+        if index_url:
+            # Pin to the trusted index and do not fall back to PyPI.
+            cmd += ["--index-url", index_url]
         if upgrade:
             cmd.append("--upgrade")
 

--- a/tests/core/test_plugin_supply_chain.py
+++ b/tests/core/test_plugin_supply_chain.py
@@ -1,0 +1,73 @@
+"""Supply-chain hardening for plugin installation (P2-5).
+
+`pip install` runs an arbitrary build backend, so where the package comes from
+matters. These tests assert the index-pinning and fail-closed strict mode without
+ever actually shelling out to pip.
+"""
+
+import types
+
+import pytest
+
+from core.plugin.loader import PluginLoader
+
+
+class _FakeProc:
+    returncode = 0
+    stdout = ""
+    stderr = ""
+
+
+@pytest.fixture
+def loader(monkeypatch):
+    ld = PluginLoader()
+    # never re-scan the environment during a unit test
+    monkeypatch.setattr(ld, "discover_plugins", lambda force=False: {})
+    return ld
+
+
+def _capture_pip(monkeypatch):
+    calls = {}
+
+    def fake_run(cmd, *a, **k):
+        calls["cmd"] = cmd
+        return _FakeProc()
+
+    monkeypatch.setattr("core.plugin.loader.subprocess.run", fake_run)
+    return calls
+
+
+def test_pins_to_configured_index(loader, monkeypatch):
+    monkeypatch.setenv("FLYTO_PLUGIN_INDEX_URL", "https://pypi.internal/simple")
+    monkeypatch.delenv("FLYTO_PLUGIN_REQUIRE_TRUSTED_INDEX", raising=False)
+    calls = _capture_pip(monkeypatch)
+
+    assert loader.install_plugin("flyto-plugin-slack", version="1.2.3") is True
+    cmd = calls["cmd"]
+    assert "--index-url" in cmd
+    assert "https://pypi.internal/simple" in cmd
+    assert "flyto-plugin-slack==1.2.3" in cmd
+
+
+def test_strict_mode_refuses_without_index(loader, monkeypatch):
+    monkeypatch.setenv("FLYTO_PLUGIN_REQUIRE_TRUSTED_INDEX", "1")
+    monkeypatch.delenv("FLYTO_PLUGIN_INDEX_URL", raising=False)
+    calls = _capture_pip(monkeypatch)
+
+    assert loader.install_plugin("flyto-plugin-slack") is False
+    assert "cmd" not in calls  # pip was never invoked
+
+
+def test_default_install_still_works_without_index(loader, monkeypatch):
+    monkeypatch.delenv("FLYTO_PLUGIN_INDEX_URL", raising=False)
+    monkeypatch.delenv("FLYTO_PLUGIN_REQUIRE_TRUSTED_INDEX", raising=False)
+    calls = _capture_pip(monkeypatch)
+
+    assert loader.install_plugin("flyto-plugin-slack") is True
+    assert "--index-url" not in calls["cmd"]
+
+
+def test_invalid_version_rejected(loader, monkeypatch):
+    calls = _capture_pip(monkeypatch)
+    assert loader.install_plugin("flyto-plugin-slack", version="1.0; rm -rf /") is False
+    assert "cmd" not in calls


### PR DESCRIPTION
`install_plugin` shells out to `pip install`, which runs the package's build backend — **arbitrary code**. The existing name/version validation limits the *name* reaching pip but does nothing against a **hostile publisher of a legit-looking `flyto-plugin-*` on public PyPI** (supply-chain RCE).

## Fix — two opt-in protections (default behaviour unchanged, CLI keeps working)
- **`FLYTO_PLUGIN_INDEX_URL`** — when set, install only from that private/curated index via `--index-url` (no public-PyPI fallback).
- **`FLYTO_PLUGIN_REQUIRE_TRUSTED_INDEX=1`** — refuse to install unless a trusted index is configured. Fail closed for hardened / red-team deployments.

## Verification
`tests/core/test_plugin_supply_chain.py` (no real pip — `subprocess.run` faked): install pins to the configured index; strict mode refuses **and never invokes pip** without one; default install still works; invalid version still rejected.

> Note: 3 `tests/runtime/test_manager.py::TestPluginManagerDiscovery` failures in the broad `-k plugin` run are **pre-existing test-ordering pollution** — they fail identically with this change stashed, and pass in isolation alongside the new tests.

## Follow-up
`--require-hashes` enforcement needs a per-plugin hash manifest (out of scope here); the index pin is the high-value control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)