### PR TITLE
security(mcp): enforce per-module required_permissions as a second lock (P0-10)

### DIFF
--- a/src/core/mcp_handler.py
+++ b/src/core/mcp_handler.py
@@ -180,6 +180,30 @@ def _denied_module_response(module_id: str) -> dict:
     }
 
 
+def _module_missing_permissions(module_id: str) -> list:
+    """Dangerous required_permissions a module declares that aren't granted."""
+    from core.module_policy import missing_permissions
+    try:
+        from core.modules.registry import ModuleRegistry
+        meta = ModuleRegistry.get_metadata(module_id) or {}
+    except Exception:
+        meta = {}
+    return missing_permissions(meta.get("required_permissions"))
+
+
+def _denied_permissions_response(module_id: str, missing: list) -> dict:
+    return {
+        "ok": False,
+        "error": (
+            f"Module '{module_id}' requires permission(s) {missing} that have not "
+            "been granted. These grant host code execution or money movement and "
+            "must be enabled explicitly via FLYTO_GRANTED_PERMISSIONS."
+        ),
+        "blocked_by": "required_permissions",
+        "missing_permissions": missing,
+    }
+
+
 def _collect_module_ids(obj: Any) -> set:
     """Recursively collect every `module:` id declared anywhere in a workflow dict."""
     found: set = set()
@@ -216,6 +240,11 @@ async def execute_module(
     # Capability gate — fail closed before any module is resolved/instantiated.
     if not _module_is_allowed(module_id):
         return _denied_module_response(module_id)
+
+    # Second lock: per-module dangerous permissions must be explicitly granted.
+    _missing = _module_missing_permissions(module_id)
+    if _missing:
+        return _denied_permissions_response(module_id, _missing)
 
     try:
         from core.modules.registry import ModuleRegistry
@@ -501,6 +530,24 @@ async def run_recipe(
                 ),
                 "blocked_by": "module_filter",
                 "blocked_modules": denied,
+            }
+
+        # Second lock: reject if any step needs an ungranted dangerous permission.
+        perm_blocked = {}
+        for m in sorted(_collect_module_ids(workflow)):
+            miss = _module_missing_permissions(m)
+            if miss:
+                perm_blocked[m] = miss
+        if perm_blocked:
+            return {
+                "ok": False,
+                "error": (
+                    f"Recipe '{recipe_name}' is blocked: step modules need permissions "
+                    "that have not been granted (FLYTO_GRANTED_PERMISSIONS): "
+                    + ", ".join(f"{m}={miss}" for m, miss in perm_blocked.items())
+                ),
+                "blocked_by": "required_permissions",
+                "blocked_modules": sorted(perm_blocked),
             }
 
         engine = WorkflowEngine(

--- a/src/core/module_policy.py
+++ b/src/core/module_policy.py
@@ -88,3 +88,38 @@ class ModuleFilter:
 
 # Singleton — initialized on import, reads env vars once
 module_filter = ModuleFilter()
+
+
+# ---------------------------------------------------------------------------
+# Per-module capability permissions (a second lock beyond the module allowlist)
+# ---------------------------------------------------------------------------
+#
+# Modules declare required_permissions in their metadata. Most (browser.*, file,
+# network, ai, cloud) are needed by ordinary recipes and are always allowed. A
+# small set grants host code execution or money movement and must be explicitly
+# granted via FLYTO_GRANTED_PERMISSIONS — otherwise the module is refused even if
+# its module-id passed the allowlist. This makes required_permissions enforced
+# rather than decorative.
+_DANGEROUS_PERMISSIONS = frozenset({
+    "shell.execute",
+    "subprocess.execute",
+    "payment.process",
+})
+
+
+def granted_permissions() -> set:
+    raw = os.environ.get("FLYTO_GRANTED_PERMISSIONS", "")
+    return {p.strip() for p in raw.split(",") if p.strip()}
+
+
+def missing_permissions(required) -> list:
+    """Return the dangerous permissions in `required` that have NOT been granted.
+
+    An empty list means the module is permitted. Non-dangerous permissions are
+    always allowed (returned never lists them).
+    """
+    granted = granted_permissions()
+    return [
+        p for p in (required or [])
+        if p in _DANGEROUS_PERMISSIONS and p not in granted
+    ]

--- a/tests/core/test_required_permissions.py
+++ b/tests/core/test_required_permissions.py
@@ -1,0 +1,74 @@
+"""Per-module required_permissions enforcement (P0-10) — a second lock beyond the
+module-id allowlist. Dangerous permissions (shell/subprocess/payment) must be
+explicitly granted via FLYTO_GRANTED_PERMISSIONS even if the module-id is allowed."""
+
+import pytest
+
+from core.modules import atomic  # noqa: F401 — registers modules
+
+import core.module_policy as module_policy
+from core.module_policy import ModuleFilter, missing_permissions
+from core.mcp_handler import execute_module, run_recipe
+
+
+def _allow_all(monkeypatch, granted=None):
+    """Make the module filter allow everything, set the granted-permission env."""
+    monkeypatch.setenv("FLYTO_MODULE_ALLOWLIST", "*")
+    if granted is None:
+        monkeypatch.delenv("FLYTO_GRANTED_PERMISSIONS", raising=False)
+    else:
+        monkeypatch.setenv("FLYTO_GRANTED_PERMISSIONS", granted)
+    monkeypatch.setattr(module_policy, "module_filter", ModuleFilter())
+
+
+class TestMissingPermissions:
+    def test_dangerous_requires_grant(self, monkeypatch):
+        monkeypatch.delenv("FLYTO_GRANTED_PERMISSIONS", raising=False)
+        assert "subprocess.execute" in missing_permissions(["subprocess.execute"])
+        assert "payment.process" in missing_permissions(["payment.process"])
+
+    def test_safe_permissions_always_allowed(self, monkeypatch):
+        monkeypatch.delenv("FLYTO_GRANTED_PERMISSIONS", raising=False)
+        assert missing_permissions(["browser.automation", "filesystem.read", "network.access"]) == []
+        assert missing_permissions([]) == []
+
+    def test_grant_clears_it(self, monkeypatch):
+        monkeypatch.setenv("FLYTO_GRANTED_PERMISSIONS", "subprocess.execute,payment.process")
+        assert missing_permissions(["subprocess.execute"]) == []
+        assert missing_permissions(["payment.process"]) == []
+
+
+@pytest.mark.asyncio
+class TestExecuteModulePermissionGate:
+    async def test_blocked_when_permission_not_granted(self, monkeypatch):
+        # module-id allowed, but subprocess.execute not granted -> permission block
+        _allow_all(monkeypatch, granted=None)
+        res = await execute_module("sandbox.execute_shell", {"command": "id"})
+        assert res["ok"] is False
+        assert res["blocked_by"] == "required_permissions"
+        assert "subprocess.execute" in res["missing_permissions"]
+
+    async def test_passes_gate_when_granted(self, monkeypatch):
+        _allow_all(monkeypatch, granted="subprocess.execute")
+        res = await execute_module("sandbox.execute_shell", {"command": "echo hi", "timeout": 5})
+        # may actually run now — assert it is NOT stopped by either policy gate
+        assert res.get("blocked_by") not in ("required_permissions", "module_filter")
+
+    async def test_safe_module_unaffected(self, monkeypatch):
+        _allow_all(monkeypatch, granted=None)
+        res = await execute_module("string.uppercase", {"text": "hi"})
+        assert res.get("ok") is True
+
+
+@pytest.mark.asyncio
+async def test_run_recipe_blocks_on_missing_permission(monkeypatch):
+    _allow_all(monkeypatch, granted=None)
+    import cli.recipe as recipe_mod
+    poisoned = {"steps": [{"id": "s1", "module": "sandbox.execute_shell",
+                           "params": {"command": "id"}}]}
+    monkeypatch.setattr(recipe_mod, "load_recipe", lambda name: poisoned)
+    monkeypatch.setattr(recipe_mod, "substitute_args", lambda wf, args: wf)
+    res = await run_recipe("poisoned", {})
+    assert res["ok"] is False
+    assert res["blocked_by"] == "required_permissions"
+    assert "sandbox.execute_shell" in res["blocked_modules"]


### PR DESCRIPTION
Stacked on #29 (`security/mcp-capability-filter`); retarget to `main` after it merges.

Modules declare `required_permissions` in metadata, but **nothing checked them** — the field was decorative. This makes it a real **second lock** beyond the module-id allowlist: a module whose id is allowed is still refused if it needs a *dangerous* permission that hasn't been granted.

## Fix
- `module_policy.missing_permissions(required)` — the dangerous set (`shell.execute`, `subprocess.execute`, `payment.process`) must be granted via **`FLYTO_GRANTED_PERMISSIONS`**. Everything ordinary recipes use (`browser.*`, `filesystem.*`, `network.*`, `ai.*`, `cloud.*`) is always allowed, so the 37 shipped recipes are unaffected.
- `execute_module` checks the dispatched module's permissions after the allowlist gate; `run_recipe` pre-flights every declared step. Both fail closed with `blocked_by=required_permissions` + the missing list.

## Verification
`tests/core/test_required_permissions.py`: dangerous-vs-safe classification; `execute_module` blocks `sandbox.execute_shell` (allowed by id) until `subprocess.execute` is granted, then passes the gate; safe modules unaffected; `run_recipe` blocks a step needing an ungranted permission. **127** MCP-suite tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)