### PR TITLE
security(mcp): enforce capability policy at the execution chokepoint — closes flow.invoke RCE bypass (pass-2 G1)

### DIFF
--- a/src/core/module_policy.py
+++ b/src/core/module_policy.py
@@ -46,6 +46,8 @@ _DEFAULT_DENYLIST = [
     "docker.run",       # container host control (docker.ps stays allowed)
     "docker.exec",
     "file.delete",      # path not validated — arbitrary host file deletion
+    "env.get",          # reads ANY host env var (API keys/DSNs) = secret exfil
+    "env.load_dotenv",  # loads a .env file from disk into workflow variables
 ]
 
 
@@ -123,3 +125,33 @@ def missing_permissions(required) -> list:
         p for p in (required or [])
         if p in _DANGEROUS_PERMISSIONS and p not in granted
     ]
+
+
+class ModulePolicyError(PermissionError):
+    """Raised at the execution chokepoint when a module is blocked by policy."""
+
+
+def enforce_module_policy(module_id, required_permissions=None) -> None:
+    """Fail-closed gate, called at the single execution chokepoint (BaseModule.run).
+
+    Raises ModulePolicyError if the module id is denied by the capability filter
+    or declares an ungranted dangerous permission. Because EVERY module — direct,
+    recipe step, foreach item, composite sub-node, and any child reached via
+    flow.invoke / template.invoke / agent tools — is executed through this gate,
+    a denied module cannot run no matter how it was invoked. The MCP-boundary
+    checks remain as a first line; this is the backstop the nested-execution
+    gadgets were bypassing.
+    """
+    if not module_id:
+        return
+    if not module_filter.is_allowed(module_id):
+        raise ModulePolicyError(
+            f"Module '{module_id}' is blocked by the capability policy "
+            "(FLYTO_MODULE_DENYLIST / FLYTO_MODULE_ALLOWLIST)."
+        )
+    missing = missing_permissions(required_permissions)
+    if missing:
+        raise ModulePolicyError(
+            f"Module '{module_id}' requires ungranted permission(s) {missing} "
+            "(grant via FLYTO_GRANTED_PERMISSIONS)."
+        )

--- a/src/core/modules/base.py
+++ b/src/core/modules/base.py
@@ -231,6 +231,15 @@ class BaseModule(ABC):
         # Get module metadata for Phase 2 settings
         metadata = ModuleRegistry.get_metadata(self.module_id) or {}
 
+        # SECURITY: single execution chokepoint. Every module — including those
+        # reached via flow.invoke / template.invoke / foreach / composite
+        # sub-nodes / agent-chosen tools — runs through here, so a denied or
+        # insufficiently-permitted module fails closed regardless of how it was
+        # invoked. This is the backstop the nested-execution gadgets used to
+        # bypass the MCP-boundary capability checks.
+        from ..module_policy import enforce_module_policy
+        enforce_module_policy(self.module_id, metadata.get('required_permissions'))
+
         timeout_ms = metadata.get('timeout_ms')
         timeout = timeout_ms / 1000.0 if timeout_ms else None
         retryable = metadata.get('retryable', False)

--- a/tests/core/test_policy_chokepoint.py
+++ b/tests/core/test_policy_chokepoint.py
@@ -1,0 +1,80 @@
+"""Execution-chokepoint enforcement (pass-2 G1).
+
+The MCP-boundary capability checks (#29/#34) were bypassable: flow.invoke /
+template.invoke / foreach / composite sub-nodes / llm.agent tools run child
+modules through a fresh engine or direct ModuleRegistry.get that never called the
+filter. This enforces the policy in BaseModule.run() — the single point every
+module execution flows through — so a denied module cannot run no matter how it
+is reached.
+"""
+
+import pytest
+
+from core.modules import atomic  # noqa: F401 — registers modules
+
+import core.module_policy as module_policy
+from core.module_policy import ModuleFilter, ModulePolicyError, enforce_module_policy
+from core.modules.registry import ModuleRegistry
+from core.modules.atomic.file.delete import FileDeleteModule
+from core.mcp_handler import execute_module
+
+
+@pytest.fixture
+def default_policy(monkeypatch):
+    """Install the default deny-by-default policy (no allowlist, no grants)."""
+    monkeypatch.delenv("FLYTO_MODULE_ALLOWLIST", raising=False)
+    monkeypatch.delenv("FLYTO_MODULE_DENYLIST", raising=False)
+    monkeypatch.delenv("FLYTO_GRANTED_PERMISSIONS", raising=False)
+    monkeypatch.setattr(module_policy, "module_filter", ModuleFilter())
+
+
+class TestEnforce:
+    def test_denied_module_raises(self, default_policy):
+        with pytest.raises(ModulePolicyError):
+            enforce_module_policy("sandbox.execute_shell", ["subprocess.execute"])
+
+    def test_env_get_now_denied_by_default(self, default_policy):
+        assert module_policy.module_filter.is_allowed("env.get") is False
+        with pytest.raises(ModulePolicyError):
+            enforce_module_policy("env.get", [])
+
+    def test_allowed_module_passes(self, default_policy):
+        enforce_module_policy("string.uppercase", [])  # no raise
+
+    def test_dangerous_permission_requires_grant(self, default_policy):
+        with pytest.raises(ModulePolicyError):
+            enforce_module_policy("string.uppercase", ["subprocess.execute"])
+
+
+@pytest.mark.asyncio
+class TestRunBackstop:
+    async def test_denied_module_blocked_at_run(self, default_policy):
+        # Construct a denied module directly (bypassing the mcp_handler gate) and
+        # call run() — the chokepoint must still block it before execute().
+        mod = FileDeleteModule({"file_path": "/tmp/should-not-be-touched"}, {})
+        with pytest.raises(ModulePolicyError):
+            await mod.run()
+
+    async def test_allowed_module_runs(self, default_policy):
+        mod = ModuleRegistry.get("string.uppercase")({"text": "hi"}, {})
+        result = await mod.run()
+        assert result["data"]["result"] == "HI"
+
+
+@pytest.mark.asyncio
+async def test_flow_invoke_cannot_run_denied_child(default_policy):
+    # The headline bypass: flow.invoke is allowed and runs an inline child
+    # workflow. A denied child module (sandbox.execute_shell) must be blocked at
+    # the chokepoint and never execute. flow.invoke surfaces a workflow error
+    # citing the policy block rather than running the command.
+    inline = (
+        "steps:\n"
+        "  - id: s1\n"
+        "    module: sandbox.execute_shell\n"
+        "    params:\n"
+        "      command: echo CHOKEPOINT\n"
+    )
+    result = await execute_module("flow.invoke", {"workflow_source": inline})
+    assert "blocked by the capability policy" in repr(result), (
+        f"denied child not blocked via flow.invoke: {result}"
+    )


### PR DESCRIPTION
**Critical** — a second-pass adversarial review found the #29/#34 capability gates are **bypassable**, re-opening host RCE. Stacked on #34 (`security/required-permissions`); retarget to `main` after #29/#34 merge.

## The bypass
#29/#34 only guard the **two MCP doorways** (`execute_module` + `run_recipe` pre-flight). Every **nested-execution gadget** — `flow.invoke` (inline-YAML child workflow), `template.invoke`, `flow.subflow`, composite sub-nodes, `foreach`, `llm.agent` `params.tools` — runs child modules through a fresh `WorkflowEngine` / direct `ModuleRegistry.get` that **never calls the filter**. So one call:
```
execute_module('flow.invoke', {workflow_source: 'steps:\n - module: shell.exec\n   params: {command: ...}'})
```
runs a **denied** module = **host RCE**, bypassing both the denylist and `required_permissions` (`_collect_module_ids` can't see an id buried in an opaque YAML string).

## The fix (real, not gadget whack-a-mole)
Enforce the policy at the **single point every module execution flows through — `BaseModule.run()`** (which already loads the module metadata). It now calls `enforce_module_policy(module_id, required_permissions)` before dispatch and fails closed (`ModulePolicyError`). Direct / recipe / foreach / composite / sub-node / `flow.invoke`+`template.invoke` child / agent-chosen — **all covered by construction**. The MCP-boundary checks stay as the first line.

Also: `env.get` + `env.load_dotenv` added to the default denylist — `env.get` reads **any** host env var (API keys/DSNs) and was allowed-by-default = a direct secret-exfil primitive.

## Verification
`tests/core/test_policy_chokepoint.py`: enforce blocks denied/missing-perm & passes allowed; `env.get` now denied; a denied module is blocked **at `run()` even when constructed directly** (bypassing the MCP gate); and **`flow.invoke` with an inline `sandbox.execute_shell` child is blocked at the chokepoint** (the headline bypass, proven closed). **327 targeted + 1318 broad** module/core tests pass; the 13 image/SSL/browser integration failures are pre-existing (identical with this change stashed).

## Part of the pass-2 red-team NO-GO unblock set
This is **G1**. Remaining gating for red-team GO (separate PRs): G2 dangerous-permission labels for `git.*`/`docker.*`/`network.*` subprocess modules + `git.clone` URL validation (ext:: RCE); G3 env-scrub for `shell.exec`/`process.start`/git/docker; G4 SSRF fail-closed (`http.request` redirect + `ssrf_protection` param + `port_scan`); G5 boundary redaction; G6 file/path isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)