### PR TITLE
security(git): reject ext:: transport + option-injection in git.clone URL (pass-2 G2)

### DIFF
--- a/src/core/modules/atomic/git/clone.py
+++ b/src/core/modules/atomic/git/clone.py
@@ -8,6 +8,7 @@ Clone a git repository to a local path
 import asyncio
 import logging
 import os
+import re
 from typing import Any, Dict
 from urllib.parse import urlparse, urlunparse
 
@@ -18,6 +19,35 @@ from ...schema.constants import FieldGroup
 
 
 logger = logging.getLogger(__name__)
+
+# git remote-helper transports (ext::, fd::, transport::cmd) execute an arbitrary
+# command — `git clone 'ext::sh -c "id"'` is RCE. Detect the `scheme::` form.
+_GIT_TRANSPORT_HELPER = re.compile(r'^[A-Za-z][A-Za-z0-9+.\-]*::')
+_ALLOWED_CLONE_SCHEMES = {'http', 'https', 'ssh', 'git', 'ftp', 'ftps', 'rsync'}
+
+
+class UnsafeCloneURL(ValueError):
+    """Raised when a clone URL could trigger command execution or local access."""
+
+
+def _validate_clone_url(url: str) -> None:
+    """Reject clone URLs that can run commands (ext::), read local files (file://),
+    inject git options (leading '-'), or hit arbitrary local paths."""
+    if not url or not url.strip():
+        raise UnsafeCloneURL("empty clone url")
+    u = url.strip()
+    if u.startswith('-'):
+        raise UnsafeCloneURL("clone url must not start with '-' (option injection)")
+    if _GIT_TRANSPORT_HELPER.match(u):
+        raise UnsafeCloneURL("git remote-helper transport (e.g. ext::) is not allowed")
+    parsed = urlparse(u)
+    if parsed.scheme and parsed.scheme.lower() not in _ALLOWED_CLONE_SCHEMES:
+        # Explicit non-allowed scheme (file://, ext:: already caught above).
+        raise UnsafeCloneURL(f"clone scheme '{parsed.scheme}' is not allowed")
+    # Scheme-less values (scp-style user@host:path or a local repo path) are a
+    # legitimate git feature and not command execution; the dangerous vectors
+    # (ext::/fd:: transports, file://, option-injecting leading '-') are already
+    # rejected above.
 
 
 def _inject_token_into_url(url: str, token: str) -> str:
@@ -37,7 +67,9 @@ def _build_clone_cmd(clone_url: str, destination: str, branch: str = None, depth
         cmd.extend(['--branch', branch])
     if depth:
         cmd.extend(['--depth', str(depth)])
-    cmd.extend([clone_url, destination])
+    # '--' terminates option parsing so neither url nor destination can be read
+    # as a git flag (defense in depth alongside _validate_clone_url).
+    cmd.extend(['--', clone_url, destination])
     return cmd
 
 
@@ -153,6 +185,10 @@ async def git_clone(context: Dict[str, Any]) -> Dict[str, Any]:
     branch = params.get('branch')
     depth = params.get('depth')
     token = params.get('token')
+
+    # SECURITY: reject ext::/file://, option-injecting, and local-path URLs before
+    # they reach `git clone` (ext:: transport = arbitrary command execution).
+    _validate_clone_url(url)
 
     clone_url = _inject_token_into_url(url, token) if token and url.startswith('https://') else url
     cmd = _build_clone_cmd(clone_url, destination, branch, depth)

--- a/tests/core/test_git_clone_url.py
+++ b/tests/core/test_git_clone_url.py
@@ -1,0 +1,45 @@
+"""git.clone URL validation — reject the ext:: transport (RCE) and other unsafe
+clone targets (pass-2 G2)."""
+
+import pytest
+
+from core.modules.atomic.git.clone import (
+    _validate_clone_url,
+    _build_clone_cmd,
+    UnsafeCloneURL,
+)
+
+
+class TestValidateCloneURL:
+    @pytest.mark.parametrize("bad", [
+        'ext::sh -c "id"',                 # remote-helper transport = RCE
+        'ext::sh -c touch /tmp/pwned',
+        'fd::17/foo',                      # another transport helper
+        'file:///etc/passwd',              # file:// scheme not allowed
+        '--upload-pack=/bin/sh',           # option injection
+        '-o ProxyCommand=sh',
+        '',                                # empty
+    ])
+    def test_rejects_unsafe(self, bad):
+        with pytest.raises(UnsafeCloneURL):
+            _validate_clone_url(bad)
+
+    @pytest.mark.parametrize("ok", [
+        'https://github.com/flytohub/flyto-core.git',
+        'http://internal.example/repo.git',
+        'ssh://git@github.com/org/repo.git',
+        'git://github.com/org/repo.git',
+        'git@github.com:org/repo.git',      # scp-style, no scheme
+        '/tmp/local/repo.git',              # local clone is a legit git feature
+    ])
+    def test_allows_normal(self, ok):
+        _validate_clone_url(ok)  # must not raise
+
+
+def test_build_cmd_uses_double_dash():
+    cmd = _build_clone_cmd('https://h/r.git', '/tmp/dest')
+    assert '--' in cmd
+    # '--' must come immediately before the positional url/destination
+    i = cmd.index('--')
+    assert cmd[i + 1] == 'https://h/r.git'
+    assert cmd[i + 2] == '/tmp/dest'


### PR DESCRIPTION
`git.clone` passed the caller-supplied `url` straight to `git clone`. git's **remote-helper transports run an arbitrary command**, so `url='ext::sh -c "id"'` (or `fd::`, or any `scheme::cmd` form) = **host RCE** — and it slipped **both** the module denylist (`git.*` isn't denied) and `required_permissions` (the module declares only `filesystem.write`/`network.connect`). Same root cause as the engine `scanner.go` clone-RCE finding.

## Fix
`_validate_clone_url` rejects:
- `ext::` / `fd::` (and any `scheme::` remote-helper) — the RCE vector
- `file://` and any non-allowlisted scheme
- leading `-` (option injection)

Allowed: `http(s)`/`ssh`/`git`/`ftp(s)`/`rsync`, scp-style `user@host:path`, and **local repo paths** (a legit git feature, not command execution). `_build_clone_cmd` also inserts `--` before the positional `url`/`destination` as defense in depth.

## Verification
`tests/core/test_git_clone_url.py`: `ext::`/`fd::`/`file://`/`--upload-pack`/`-o`/empty rejected; https/ssh/git/scp/local allowed; cmd uses `--`. Existing `TestGitModules` (including local-clone) stays green.

Part of the pass-2 red-team unblock set (**G2**). Companion follow-ups: label all `asyncio.create_subprocess_*` modules (`git.*`/`docker.*`/`network.*`) with a dangerous permission; G3 env-scrub; G4 SSRF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)