### PR TITLE
security(http): SSRF protection operator-controlled, not a client param (pass-2 G4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ requires-python = ">=3.9"
 
 dependencies = [
     "pyyaml>=6.0,<7",
-    "aiohttp>=3.9.0,<4",
+    "aiohttp>=3.13.5,<4",
     "beautifulsoup4>=4.12.0,<5",
     "lxml>=6.1.0,<7",
     "pydantic>=2.4.0,<3",
@@ -65,12 +65,12 @@ api = [
     "uvicorn>=0.24.0",
 ]
 vector = [
-    "qdrant-client>=1.7.0",
+    "qdrant-client>=1.9.0",
     "sentence-transformers>=2.2.0",
 ]
 image = [
     "qrcode[pil]>=7.0",
-    "Pillow>=10.0.0",
+    "Pillow>=11.3.0",  # GHSA-3f63 (ACE, 10.2.0) + GHSA-44wm (buffer overflow, 10.3.0) fixed; 11.3.0 is the last line supporting py3.9 (12.2.0 CVEs require py3.10)
 ]
 telegram = [
     "python-telegram-bot>=20.0",
@@ -82,10 +82,10 @@ all = [
     "flyto-core[browser,api,vector,telegram,image]",
 ]
 dev = [
-    "pytest>=7.4.0",
+    "pytest>=8.4.2",  # GHSA-6w46 tmpdir (dev/local-only) fully patched in 9.0.3 / py3.10; 8.4.2 is the last line supporting py3.9
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.1.0",
-    "black>=23.0.0",
+    "black>=25.11.0",  # GHSA-fj7x ReDoS fixed in 24.3.0; 25.11.0 is the last line supporting py3.9 (GHSA-3936 file-write fix requires black 26.3.1 / py3.10)
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "build>=1.0.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -15,10 +15,10 @@
 # Core dependencies (from pyproject.toml)
 # ============================================
 pyyaml==6.0
-aiohttp==3.11.0
+aiohttp==3.13.5  # bumped from 3.11.0 — fixes multiple CVEs (zip bomb, smuggling, DoS); 3.13.x is the last line supporting Python 3.9 (3.14.0 requires >=3.10)
 beautifulsoup4==4.12.0
 lxml==6.1.0  # bumped from 4.9.0 — was vulnerable to XXE/iterparse CVE-2026-41066
-pydantic==2.0.0
+pydantic==2.4.0  # bumped from 2.0.0 — GHSA-mr82-8j83-vxmv ReDoS fixed in 2.4.0
 python-dotenv==1.0.0
 aiofiles==23.0.0
 
@@ -39,7 +39,7 @@ uvicorn==0.24.0
 # Optional: Vector database / embeddings
 # ============================================
 # pip install flyto-core[vector]
-qdrant-client==1.7.0
+qdrant-client==1.9.0  # bumped from 1.7.0 — GHSA-7m75-x27w-r52r input validation failure fixed in 1.9.0
 sentence-transformers==2.2.0
 
 # ============================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Core dependencies
 pyyaml>=6.0
 playwright>=1.40.0
-# CVE-2024-30251: body iteration race fixed in 3.11.0
-aiohttp>=3.11.0
+# CVE-2024-30251: body iteration race fixed in 3.11.0; bumped to 3.13.5 for zip-bomb/smuggling/DoS fixes (3.14.0 requires py3.10)
+aiohttp>=3.13.5
 beautifulsoup4>=4.12.0
 # CVE-2026-41066: iterparse/ETCompatXMLParser XXE fixed in 6.1.0
 lxml>=6.1.0
@@ -11,7 +11,7 @@ lxml>=6.1.0
 # CVE-2024-24762: multipart DoS fixed in 0.115.0
 fastapi>=0.115.0
 uvicorn>=0.24.0
-pydantic>=2.0.0
+pydantic>=2.4.0  # GHSA-mr82-8j83-vxmv ReDoS fixed in 2.4.0
 
 # Firebase (if using)
 firebase-admin>=6.9.0
@@ -21,7 +21,7 @@ python-dotenv>=1.0.0
 requests>=2.32.5
 
 # Vector Database (for long-term memory)
-qdrant-client>=1.7.0
+qdrant-client>=1.9.0  # GHSA-7m75-x27w-r52r input validation fixed in 1.9.0
 sentence-transformers>=2.2.0  # For local embeddings
 
 # ============================================

--- a/src/core/modules/atomic/http/batch.py
+++ b/src/core/modules/atomic/http/batch.py
@@ -15,7 +15,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from ...registry import register_module
-from ....utils import validate_url_with_env_config, SSRFError
+from ....utils import validate_url_with_env_config, SSRFError, ssrf_protection_enabled
 
 
 logger = logging.getLogger(__name__)
@@ -220,7 +220,7 @@ async def http_batch(context: Dict[str, Any]) -> Dict[str, Any]:
     measure_time = bool(params.get('measure_time', False))
     timeout_s = int(params.get('timeout', 30))
     verify_ssl = bool(params.get('verify_ssl', True))
-    ssrf_on = bool(params.get('ssrf_protection', True))
+    ssrf_on = ssrf_protection_enabled()  # operator-controlled, not client param
     patterns: List[str] = list(params.get('detect_patterns') or [])
 
     # SSRF gate — refuse any target that fails the project's URL validator

--- a/src/core/modules/atomic/http/get.py
+++ b/src/core/modules/atomic/http/get.py
@@ -12,7 +12,7 @@ from typing import Any, Dict
 from ...registry import register_module
 from ...errors import ValidationError, NetworkError, ModuleError
 from ...schema import compose, presets
-from ....utils import validate_url_with_env_config, SSRFError
+from ....utils import validate_url_with_env_config, SSRFError, ssrf_protection_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ async def http_get(context: Dict[str, Any]) -> Dict[str, Any]:
     timeout_s = params.get('timeout', 30)
     verify_ssl = params.get('verify_ssl', True)
 
-    if params.get('ssrf_protection', True):
+    if ssrf_protection_enabled():
         try:
             validate_url_with_env_config(url)
         except SSRFError as e:

--- a/src/core/modules/atomic/http/request.py
+++ b/src/core/modules/atomic/http/request.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Union
 from ...registry import register_module
 from ...schema import compose, field, presets
 from ...schema.constants import Visibility, FieldGroup
-from ....utils import validate_url_with_env_config, SSRFError
+from ....utils import validate_url_with_env_config, SSRFError, ssrf_protection_enabled
 
 
 logger = logging.getLogger(__name__)
@@ -308,7 +308,7 @@ async def http_request(context: Dict[str, Any]) -> Dict[str, Any]:
             f"Use ${{variable_name}} syntax and ensure the variable is defined.",
             'UNRESOLVED_VARIABLE', url, 0)
 
-    if params.get('ssrf_protection', True):
+    if ssrf_protection_enabled():
         try:
             validate_url_with_env_config(url)
         except SSRFError as e:

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -528,6 +528,21 @@ def get_ssrf_config() -> dict:
     }
 
 
+def ssrf_protection_enabled() -> bool:
+    """Whether outbound HTTP modules must run the SSRF guard.
+
+    SSRF protection is OPERATOR-controlled, never disableable by a recipe/client
+    `ssrf_protection` param (an untrusted MCP client could otherwise just pass
+    ssrf_protection=false and reach 169.254.169.254 / internal services).
+    Default ON; an operator may opt out for trusted/local use via
+    FLYTO_HTTP_DISABLE_SSRF_GUARD=1. Legitimate internal access should instead be
+    granted narrowly with FLYTO_ALLOW_PRIVATE_NETWORK / FLYTO_ALLOWED_HOSTS.
+    """
+    return os.environ.get("FLYTO_HTTP_DISABLE_SSRF_GUARD", "").strip().lower() not in (
+        "1", "true", "yes", "on"
+    )
+
+
 def validate_url_with_env_config(url: str) -> str:
     """
     Validate URL using environment-based SSRF configuration.

--- a/tests/core/test_http_ssrf_operator_only.py
+++ b/tests/core/test_http_ssrf_operator_only.py
@@ -1,0 +1,40 @@
+"""SSRF protection must be operator-controlled, not disableable by a client/recipe
+`ssrf_protection` param (pass-2 G4)."""
+
+import pytest
+
+from core.modules import atomic  # noqa: F401 — registers modules
+from core.utils import ssrf_protection_enabled
+from core.mcp_handler import execute_module
+
+METADATA = "http://169.254.169.254/latest/meta-data/"
+
+
+class TestHelper:
+    def test_default_on(self, monkeypatch):
+        monkeypatch.delenv("FLYTO_HTTP_DISABLE_SSRF_GUARD", raising=False)
+        assert ssrf_protection_enabled() is True
+
+    def test_operator_can_disable(self, monkeypatch):
+        monkeypatch.setenv("FLYTO_HTTP_DISABLE_SSRF_GUARD", "1")
+        assert ssrf_protection_enabled() is False
+
+
+@pytest.mark.asyncio
+class TestParamCannotDisable:
+    async def test_http_request_param_false_still_blocks_metadata(self, monkeypatch):
+        monkeypatch.delenv("FLYTO_HTTP_DISABLE_SSRF_GUARD", raising=False)
+        # Attacker tries to turn off the guard via the request param.
+        res = await execute_module("http.request", {
+            "url": METADATA, "method": "GET", "ssrf_protection": False,
+        })
+        text = repr(res).lower()
+        assert "ssrf" in text or "blocked" in text or res.get("ok") is False
+
+    async def test_http_get_param_false_still_blocks_metadata(self, monkeypatch):
+        monkeypatch.delenv("FLYTO_HTTP_DISABLE_SSRF_GUARD", raising=False)
+        res = await execute_module("http.get", {
+            "url": METADATA, "ssrf_protection": False,
+        })
+        assert res.get("ok") is not True
+        assert "169.254" not in str(res.get("data", "")) or res.get("ok") is False


### PR DESCRIPTION
`http.request` / `http.get` / `http.batch` gated the SSRF guard on `params.get('ssrf_protection', True)` — so an untrusted MCP client / poisoned recipe simply passes **`ssrf_protection: false`** and reaches `169.254.169.254` (cloud metadata) and internal services. The guard was **attacker-disableable**.

## Fix
New `utils.ssrf_protection_enabled()` makes it **operator-controlled**: default **ON**, only an explicit server-side `FLYTO_HTTP_DISABLE_SSRF_GUARD=1` turns it off. The client `ssrf_protection` param is no longer honored. Legitimate internal access stays grantable narrowly via `FLYTO_ALLOW_PRIVATE_NETWORK` / `FLYTO_ALLOWED_HOSTS`.

## Verification
`tests/core/test_http_ssrf_operator_only.py`: helper default-on / operator-disable; `http.request` and `http.get` with `ssrf_protection=false` **still block** a metadata URL. **164** http tests pass (2 pre-existing self-signed-SSL env errors, unrelated).

Part of pass-2 red-team unblock (**G4**). Remaining G4: revalidate each redirect `Location` (the `allow_redirects` bypass) and apply the guard to `network.port_scan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)