### PR TITLE
Add CaptchaAI as a captcha solver provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Captcha: CaptchaAI provider** — `CaptchaSolver` now accepts
+  `provider='captchaai'`. CaptchaAI is 2Captcha-API-compatible (in.php/res.php),
+  so it reuses the existing 2Captcha submit/poll path against
+  `https://ocr.captchaai.com` (reCAPTCHA v2/v3, Cloudflare Turnstile). Also
+  added to the `browser.challenge` captcha-solver dropdown.
 - Added generic `verification.discover`, `verification.generate_scenarios`,
   `verification.run`, and `verification.report` module IDs as the forward path
   for deterministic verification primitives. Existing `warroom.*` modules stay

--- a/src/core/browser/captcha.py
+++ b/src/core/browser/captcha.py
@@ -1,12 +1,17 @@
 # Copyright 2026 Flyto2. Licensed under Apache-2.0. See LICENSE.
 
 """
-Captcha Solver — API-based solving via 2Captcha or CapSolver
+Captcha Solver — API-based solving via 2Captcha, CapSolver, or CaptchaAI
 
 Supports:
 - reCAPTCHA v2/v3
 - hCaptcha
 - Cloudflare Turnstile
+
+CaptchaAI is 2Captcha-API-compatible (in.php/res.php), so it reuses the
+2Captcha submit/poll path with a different base URL. It covers reCAPTCHA v2/v3
+and Cloudflare Turnstile; it does not solve hCaptcha (use 2Captcha/CapSolver for
+that), so hCaptcha tasks are not routed to it.
 
 Flow:
 1. Detect captcha type + extract sitekey from page
@@ -161,9 +166,16 @@ _INJECT_TOKEN_JS = {
 
 
 class CaptchaSolver:
-    """API-based captcha solver supporting 2Captcha and CapSolver."""
+    """API-based captcha solver supporting 2Captcha, CapSolver, and CaptchaAI."""
 
-    PROVIDERS = ('2captcha', 'capsolver')
+    PROVIDERS = ('2captcha', 'capsolver', 'captchaai')
+
+    # Base URLs for 2Captcha-compatible providers (in.php/res.php protocol).
+    # CaptchaAI shares 2Captcha's API, so it only needs a different host.
+    _2CAPTCHA_BASE_URLS = {
+        '2captcha': 'https://2captcha.com',
+        'captchaai': 'https://ocr.captchaai.com',
+    }
 
     def __init__(self, provider: str, api_key: str):
         if provider not in self.PROVIDERS:
@@ -262,22 +274,23 @@ class CaptchaSolver:
     # ── Provider APIs ────────────────────────────────────────────
 
     async def _submit_task(self, captcha_type: str, sitekey: str, page_url: str) -> Optional[str]:
-        if self.provider == '2captcha':
+        if self.provider in self._2CAPTCHA_BASE_URLS:
             return await self._submit_2captcha(captcha_type, sitekey, page_url)
         elif self.provider == 'capsolver':
             return await self._submit_capsolver(captcha_type, sitekey, page_url)
         return None
 
     async def _poll_result(self, task_id: str) -> Optional[str]:
-        if self.provider == '2captcha':
+        if self.provider in self._2CAPTCHA_BASE_URLS:
             return await self._poll_2captcha(task_id)
         elif self.provider == 'capsolver':
             return await self._poll_capsolver(task_id)
         return None
 
-    # ── 2Captcha ─────────────────────────────────────────────────
+    # ── 2Captcha (also used by CaptchaAI — same in.php/res.php protocol) ──
 
     async def _submit_2captcha(self, captcha_type, sitekey, page_url) -> Optional[str]:
+        base_url = self._2CAPTCHA_BASE_URLS[self.provider]
         params = {
             'key': self.api_key,
             'method': 'userrecaptcha',
@@ -287,6 +300,9 @@ class CaptchaSolver:
         }
 
         if captcha_type == 'hcaptcha':
+            if self.provider == 'captchaai':
+                logger.error("CaptchaAI does not support hCaptcha; use 2captcha or capsolver for hCaptcha")
+                return None
             params['method'] = 'hcaptcha'
             params['sitekey'] = sitekey
             del params['googlekey']
@@ -302,15 +318,16 @@ class CaptchaSolver:
         # Use POST to avoid leaking API key in URL/access logs
         resp = await asyncio.to_thread(
             self._http_post,
-            'https://2captcha.com/in.php',
+            f'{base_url}/in.php',
             params,
         )
         if resp and resp.get('status') == 1:
             return resp.get('request')
-        logger.error(f"2Captcha submit failed: status={resp.get('status') if resp else None}")
+        logger.error(f"{self.provider} submit failed: status={resp.get('status') if resp else None}")
         return None
 
     async def _poll_2captcha(self, task_id: str, timeout: int = 120) -> Optional[str]:
+        base_url = self._2CAPTCHA_BASE_URLS[self.provider]
         # Use POST to avoid leaking API key in URL/access logs
         params = {
             'key': self.api_key,
@@ -322,13 +339,13 @@ class CaptchaSolver:
             await asyncio.sleep(5)
             resp = await asyncio.to_thread(
                 self._http_post,
-                'https://2captcha.com/res.php',
+                f'{base_url}/res.php',
                 params,
             )
             if resp and resp.get('status') == 1:
                 return resp.get('request')
             if resp and 'ERROR' in str(resp.get('request', '')):
-                logger.error(f"2Captcha error: {resp.get('request')}")
+                logger.error(f"{self.provider} error: {resp.get('request')}")
                 return None
         return None
 

--- a/src/core/modules/atomic/browser/challenge.py
+++ b/src/core/modules/atomic/browser/challenge.py
@@ -120,6 +120,7 @@ _CHECK_RESOLVED_JS = r"""
                   {'value': '', 'label': 'None (auto-wait + human only)'},
                   {'value': '2captcha', 'label': '2Captcha'},
                   {'value': 'capsolver', 'label': 'CapSolver'},
+                  {'value': 'captchaai', 'label': 'CaptchaAI'},
               ],
               group='basic'),
         field('captcha_api_key', type='string',
@@ -127,7 +128,7 @@ _CHECK_RESOLVED_JS = r"""
               description='API key for the captcha solving service',
               format='password',
               required=False,
-              showIf={"captcha_provider": {"$in": ["2captcha", "capsolver"]}},
+              showIf={"captcha_provider": {"$in": ["2captcha", "capsolver", "captchaai"]}},
               group='basic'),
 
         field('human_fallback', type='boolean',

--- a/tests/browser/test_captcha.py
+++ b/tests/browser/test_captcha.py
@@ -6,7 +6,7 @@ from core.browser.captcha import CaptchaSolver, _EXTRACT_CAPTCHA_INFO_JS
 
 class TestCaptchaSolverInit:
     def test_valid_providers(self):
-        for provider in ('2captcha', 'capsolver'):
+        for provider in ('2captcha', 'capsolver', 'captchaai'):
             solver = CaptchaSolver(provider, 'test-key')
             assert solver.provider == provider
 
@@ -109,3 +109,27 @@ class TestCaptchaSolve:
                 })
         assert result['status'] == 'error'
         assert 'timed out' in result['error']
+
+
+class TestCaptchaAIProvider:
+    """CaptchaAI is 2Captcha-API-compatible and reuses the in.php/res.php path."""
+
+    @pytest.mark.asyncio
+    async def test_submit_uses_captchaai_base_url(self):
+        solver = CaptchaSolver('captchaai', 'key')
+        with patch.object(solver, '_http_post', return_value={'status': 1, 'request': 'task-123'}) as post:
+            task_id = await solver._submit_task('recaptcha_v2', 'sitekey-abc', 'https://example.com')
+        assert task_id == 'task-123'
+        url, params = post.call_args.args[0], post.call_args.args[1]
+        assert url == 'https://ocr.captchaai.com/in.php'
+        assert params['method'] == 'userrecaptcha'
+        assert params['googlekey'] == 'sitekey-abc'
+
+    @pytest.mark.asyncio
+    async def test_poll_uses_captchaai_base_url(self):
+        solver = CaptchaSolver('captchaai', 'key')
+        with patch('asyncio.sleep', new=AsyncMock()):
+            with patch.object(solver, '_http_post', return_value={'status': 1, 'request': 'token-xyz'}) as post:
+                token = await solver._poll_result('task-123')
+        assert token == 'token-xyz'
+        assert post.call_args.args[0] == 'https://ocr.captchaai.com/res.php'


### PR DESCRIPTION
Per #39 (thanks @ChesterHsu for the invite) — adds CaptchaAI as a third provider in `CaptchaSolver`.

Since CaptchaAI is 2Captcha-API-compatible (`in.php`/`res.php`), it reuses the existing 2Captcha submit/poll path via a small base-URL map (`https://ocr.captchaai.com`) rather than duplicating logic. Changes:

- `captcha.py`: add `captchaai` to `PROVIDERS`; route it through the 2Captcha path via `_2CAPTCHA_BASE_URLS`. Covers reCAPTCHA v2/v3 + Cloudflare Turnstile. hCaptcha is explicitly refused for `captchaai` (CaptchaAI doesn't solve hCaptcha — use 2captcha/capsolver for that).
- `challenge.py`: add CaptchaAI to the provider dropdown + the api-key `showIf`.
- `test_captcha.py`: cover the new provider.
- `CHANGELOG.md`: note the addition.

No new dependencies. Happy to adjust naming/style to your preference.