### PR TITLE
feat: add Tavily web search module as parallel search option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@ QDRANT_PATH=.flyto/qdrant_storage
 QDRANT_URL=
 QDRANT_API_KEY=
 
+# Optional search provider.
+TAVILY_API_KEY=
+
 # Optional connector credentials. Keep blank in committed examples.
 GITHUB_TOKEN=
 SLACK_WEBHOOK_URL=

--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -313,6 +313,7 @@
 | `core.api.http_get` | Send HTTP GET request to any URL | `url` string *(required)*, `headers` object (default: `{}`), `params` object (default: `{}`), `timeout` number (default: `30`), `verify_ssl` boolean (default: `True`) | `status_code` (number), `headers` (object), `body` (string), `json` (object) |
 | `core.api.http_post` | Send HTTP POST request to any URL | `url` string *(required)*, `headers` object (default: `{}`), `body` string, `json` any, `timeout` number (default: `30`), `verify_ssl` boolean (default: `True`) | `status_code` (number), `headers` (object), `body` (string), `json` (object) |
 | `core.api.serpapi_search` | Use SerpAPI to search keywords (100 free searches/month) | `keyword` string *(required)*, `limit` number (default: `10`) | `status` (string), `data` (array), `count` (number) |
+| `core.api.tavily_search` | Use Tavily API to search the web (1000 free credits/month) | `keyword` string *(required)*, `limit` number (default: `10`) | `status` (string), `data` (array), `count` (number) |
 
 ## crypto
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ image = [
 telegram = [
     "python-telegram-bot>=22.8",
 ]
+search = [
+    "tavily-python>=0.5",
+]
 cloud = [
     "flyto-core[browser,image]",
 ]

--- a/scripts/fix_credential_keys.py
+++ b/scripts/fix_credential_keys.py
@@ -23,6 +23,7 @@ CREDENTIAL_MAPPING = {
     'api.google_sheets': ['GOOGLE_CREDENTIALS'],
     'core.api.google_search': ['GOOGLE_API_KEY', 'GOOGLE_CSE_ID'],
     'core.api.serpapi': ['SERPAPI_KEY'],
+    'core.api.tavily_search': ['TAVILY_API_KEY'],
 
     # Notion
     'api.notion': ['NOTION_TOKEN'],

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -210,6 +210,9 @@ class APIEndpoints:
     # SerpAPI
     SERPAPI_BASE_URL: str = "https://serpapi.com/search"
 
+    # Tavily
+    TAVILY_BASE_URL: str = "https://api.tavily.com/search"
+
     # Airtable
     AIRTABLE_BASE_URL: str = "https://api.airtable.com/v0"
 
@@ -286,6 +289,7 @@ class EnvVars:
     GOOGLE_AI_API_KEY: str = "GOOGLE_AI_API_KEY"
     GOOGLE_SEARCH_ENGINE_ID: str = "GOOGLE_SEARCH_ENGINE_ID"
     SERPAPI_KEY: str = "SERPAPI_KEY"
+    TAVILY_API_KEY: str = "TAVILY_API_KEY"
     STRIPE_API_KEY: str = "STRIPE_API_KEY"
     AIRTABLE_API_KEY: str = "AIRTABLE_API_KEY"
     OPENAI_API_KEY: str = "OPENAI_API_KEY"

--- a/src/core/modules/third_party/developer/http/__init__.py
+++ b/src/core/modules/third_party/developer/http/__init__.py
@@ -6,12 +6,13 @@ HTTP and API Modules Package
 API-related modules for making HTTP requests and search API calls.
 """
 
-from .search import GoogleSearchAPIModule, SerpAPISearchModule
+from .search import GoogleSearchAPIModule, SerpAPISearchModule, TavilySearchModule
 from .requests import HTTPGetModule, HTTPPostModule
 
 __all__ = [
     "GoogleSearchAPIModule",
     "SerpAPISearchModule",
+    "TavilySearchModule",
     "HTTPGetModule",
     "HTTPPostModule",
 ]

--- a/src/core/modules/third_party/developer/http/search.py
+++ b/src/core/modules/third_party/developer/http/search.py
@@ -3,7 +3,7 @@
 """
 Search API Modules
 
-Google Search and SerpAPI integration modules.
+Google Search, SerpAPI, and Tavily integration modules.
 """
 
 import os
@@ -210,6 +210,110 @@ class SerpAPISearchModule(BaseModule):
                         'title': item.get('title'),
                         'url': item.get('link'),
                         'description': item.get('snippet')
+                    })
+
+                return {
+                    "status": "success",
+                    "data": results,
+                    "count": len(results)
+                }
+
+
+@register_module(
+    module_id='core.api.tavily_search',
+    version='1.0.0',
+    category='api',
+    subcategory='api',
+    tags=['api', 'search', 'tavily', 'third-party', 'ssrf_protected'],
+    label='Web Search (Tavily)',
+    label_key='modules.api.tavily_search.label',
+    description='Use Tavily API to search the web (1000 free credits/month)',
+    description_key='modules.api.tavily_search.description',
+    icon='Search',
+    color='#5B4FDB',
+    input_types=['string'],
+    output_types=['json', 'array', 'api_response'],
+    can_connect_to=['data.*', 'notify.*', 'file.*'],
+    can_receive_from=['start', 'flow.*'],
+    timeout_ms=30000,
+    retryable=True,
+    max_retries=3,
+    concurrent_safe=True,
+    requires_credentials=True,
+    credential_keys=['TAVILY_API_KEY'],
+    handles_sensitive_data=False,
+    required_permissions=['network.access'],
+    params_schema=compose(
+        presets.SEARCH_KEYWORD(placeholder='python tutorial'),
+        presets.SEARCH_LIMIT(),
+    ),
+    output_schema={
+        'status': {'type': 'string', 'description': 'Operation status (success/error)'},
+        'data': {'type': 'array', 'description': 'Output data from the operation'},
+        'count': {'type': 'number', 'description': 'Number of items'}
+    },
+    examples=[{
+        'title': 'Search with Tavily',
+        'params': {
+            'keyword': 'machine learning',
+            'limit': 10
+        }
+    }],
+    author='Flyto2 Team',
+    license='MIT'
+)
+class TavilySearchModule(BaseModule):
+    """Tavily Search Module - Use Tavily API for web search"""
+
+    module_name = "Web Search (Tavily)"
+    module_description = "Use Tavily API to search the web (1000 free credits/month)"
+    required_permission = "api.search"
+
+    def validate_params(self) -> None:
+        if 'keyword' not in self.params:
+            raise ValueError("Missing parameter: keyword")
+        self.keyword = self.params['keyword']
+        self.limit = self.params.get('limit', 10)
+
+    async def execute(self) -> Any:
+        api_key = os.getenv('TAVILY_API_KEY')
+
+        if not api_key:
+            return {
+                "status": "error",
+                "message": "Please set TAVILY_API_KEY environment variable",
+                "setup_guide": {
+                    "step1": "Go to https://app.tavily.com/",
+                    "step2": "Register account (1000 free API credits per month)",
+                    "step3": "Get API Key",
+                    "step4": "Set environment variable: TAVILY_API_KEY"
+                }
+            }
+
+        url = "https://api.tavily.com/search"
+        payload = {
+            'api_key': api_key,
+            'query': self.keyword,
+            'max_results': self.limit,
+            'search_depth': 'basic',
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload) as response:
+                if response.status != 200:
+                    return {
+                        "status": "error",
+                        "message": f"API error: HTTP {response.status}"
+                    }
+
+                data = await response.json()
+
+                results = []
+                for item in data.get('results', []):
+                    results.append({
+                        'title': item.get('title'),
+                        'url': item.get('url'),
+                        'description': item.get('content')
                     })
 
                 return {

--- a/tests/snapshots/production_modules.json
+++ b/tests/snapshots/production_modules.json
@@ -1,5 +1,5 @@
 {
-  "total": 427,
+  "total": 428,
   "modules": [
     {
       "id": "agent.autonomous",
@@ -535,6 +535,10 @@
     },
     {
       "id": "core.api.serpapi_search",
+      "version": "1.0.0"
+    },
+    {
+      "id": "core.api.tavily_search",
       "version": "1.0.0"
     },
     {


### PR DESCRIPTION
## Summary

Adds `core.api.tavily_search` as a new search module alongside the existing `core.api.google_search` and `core.api.serpapi_search` modules. This is an **additive** change — existing providers are untouched.

The new `TavilySearchModule` uses `aiohttp` to POST to the Tavily Search API, normalizing results to the same `{title, url, description}` shape used by the other search modules. It follows the identical `@register_module` decorator pattern with `credential_keys=['TAVILY_API_KEY']`.

## Files changed

- `src/core/modules/third_party/developer/http/search.py` — Added `TavilySearchModule` class
- `src/core/modules/third_party/developer/http/__init__.py` — Exported `TavilySearchModule` in `__all__`
- `src/core/constants.py` — Added `TAVILY_BASE_URL` to `APIEndpoints`, `TAVILY_API_KEY` to `EnvVars`
- `.env.example` — Added `TAVILY_API_KEY=` entry
- `pyproject.toml` — Added `[project.optional-dependencies] search` group with `tavily-python>=0.5`
- `docs/TOOL_CATALOG.md` — Added `core.api.tavily_search` row in API section
- `tests/snapshots/production_modules.json` — Added module entry, bumped total to 428
- `scripts/fix_credential_keys.py` — Added `core.api.tavily_search` credential mapping

## Dependency changes

- Added `tavily-python>=0.5` as optional dependency in `[project.optional-dependencies] search`

## Environment variable changes

- Added `TAVILY_API_KEY` (optional) to `.env.example` and `EnvVars` constants

## Notes for reviewers

- The module uses direct `aiohttp` POST (not the `tavily-python` SDK) to match the existing pattern in `SerpAPISearchModule` and avoid a hard runtime dependency.
- `tavily-python` is listed as an optional dep for users who want SDK access elsewhere, but the module itself only needs `aiohttp` (already a core dependency).
- No existing modules or workflows are affected; the new module is only used when explicitly referenced by `module_id`.


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is additive, functionally correct, and consistent with the existing search module patterns. All required supporting files (constants, exports, env example, tool catalog, snapshot, credential keys script) are properly updated. One major issue exists: the `search` optional dependency in `pyproject.toml` declares `tavily-python>=0.5` but the implementation never imports or uses it — calling the Tavily API directly via `aiohttp` instead. This creates a phantom dependency. A minor issue is that the `TAVILY_BASE_URL` constant is defined but not referenced in the module (though this is consistent with the existing SerpAPI and Google patterns). The API call shape (POST with `api_key` in body, `query`, `max_results`) is valid for the Tavily v1 API.
