### PR TITLE
Fix the sub-workflow tool, and write the ladder into the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Every module now reports how far its effect was followed, on one shared
+  vocabulary. `dispatched -> accepted -> observed -> verified` is ordered, and
+  `failed` / `indeterminate` sit off it; only `verified` may be drawn as
+  success, because it means a postcondition was evaluated and held. 200 of the
+  483 modules are side-effecting and a ratchet counts the ones still reporting
+  nothing, so the gap is visible rather than absent. A rung must name the line
+  that measured it, and the rule that decides every one of them is: would this
+  value read the same if the effect had NOT happened? If yes, it is not
+  evidence.
+- `failed` and `indeterminate` are deliberately different answers, and the
+  difference is operational rather than cosmetic. A notification that Slack
+  rejected with a 4xx is FAILED; the same call answered with a 5xx is
+  INDETERMINATE, because the POST was already in Slack's hands and nobody can
+  say whether it landed. Retrying a failure is safe; retrying an indeterminate
+  write may do it twice, which for a message or a payment is a second one.
+- A module may now report a rung from a raise. `OutcomeError` carries an
+  envelope out through an exception, and `browser.wait` uses it: a wait that
+  times out is INDETERMINATE by this contract -- we do not know whether the
+  thing happened, only that it had not by the deadline -- and it had previously
+  reached every consumer as a definite failure. Opt-in and off-ladder only; a
+  module raising anything else still reads as FAILED.
+- An LLM agent is told the rung of every tool it calls, as a labelled line
+  ahead of the result rather than a field inside it, and the agent's system
+  prompt now defines the vocabulary. The line's position is what makes it
+  useful: tool results are truncated at 8000 characters from the tail and the
+  envelope is normally the last key, so on a large result the rung had been
+  vanishing exactly where a model is least able to check for itself. The
+  instruction that matters is on `indeterminate` -- do not assume it happened,
+  and do not retry to make sure.
+
+
 - `browser.click` now reports what it actually observed, and the engine records
   it. A click on a link that declares `target="_blank"` whose tab never opens
   still succeeds and still passes its result downstream, but the step it writes
@@ -75,6 +106,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stays 0, and no module gained a parameter.
 
 ### Fixed
+
+- A module that reported its own failure could not fail a step. Sixteen modules
+  write `rung: "failed"` into their result and the engine discarded it, because
+  the only path from a module's failure to a step's is gated on an `ok` key that
+  158 of the 483 modules never return. Reproduced on the shipped recipe
+  `scrape-to-slack.yaml` with a revoked webhook: Slack answered 404, the module
+  reported the failure correctly, and the step completed green.
+- An error-shaped result with no `ok` key was passed through raw. Six modules
+  return one, and all six completed green carrying their own error text. A
+  result is now failed when it carries a non-empty `error_code`, or a `status`
+  equal to the string `"error"` -- compared as a string, which is what keeps
+  `http.request`'s integer status and `port.check`'s `open`/`closed` out of it.
+  A bare `error` key is deliberately not enough: `reverse.sourcemap` returns one
+  as data on a step that did its job.
+- `on_error: continue` absorbed the evidence along with the error. A step that
+  raised reached a host as `status='success'` with no rung and `proved=True` --
+  a step that crashed, drawn as a proved success. The absorbed result now
+  carries `failed`, or whatever rung the module opted into.
+- The engine wrote a postcondition a module had gone out of its way not to
+  claim. A declared postcondition was stamped onto any envelope of that module
+  carrying none, including the ones that deliberately carry none:
+  `http.response_assert` called with no assertions returned `postcondition:
+  None` and the engine replaced it with "every assertion supplied by the caller
+  was evaluated ... and all of them held". It is now stamped only onto a
+  `verified` claim, the one rung the field means anything on.
+- `browser.drag` reported that it had seen the page change when only the
+  browser had scrolled. Movement was measured with `bounding_box()`, which is
+  viewport-relative, while a synthetic drag makes Chromium autoscroll -- so on
+  an app-shell layout with a scrolling content pane, a 40px card "moved" 3920
+  pixels on a page with no drag handler and no script at all. It now measures
+  layout position with every ancestor's scroll added back, which also fixes a
+  `position:fixed` source, an iframe, and a drag inside a scrollable container.
+  Separately, a drag that DELETED its source was reported as nothing at all:
+  `bounding_box()` raises rather than returning None for a removed node, so the
+  clearest possible effect read as "we could not look".
+- `browser.wait` treated a misspelled selector as an observation. `hidden` and
+  `detached` are both true of a selector that matches nothing, and a typo
+  satisfied the wait in 7ms while the real element took 1502ms to time out --
+  the typo was the faster path to a green tick. Both states now require an
+  existence witness. A page that REMOVES the nodes still counts as observed,
+  which the first version of this fix got wrong.
+- `verify.run` could not run at all. Its child modules were built with the
+  pre-`BaseModule` constructor style, so all eight call sites raised TypeError
+  and the module failed at the registry.
+- The agent's sub-workflow tool had never executed once. Its WorkflowEngine
+  import was one level short and resolved to a module that does not exist, and
+  a blanket `except Exception` presented the ModuleNotFoundError to the model as
+  an ordinary template failure. Behind it the workflow was built with `nodes`
+  and `edges` rather than `steps`, and behind that there was no recursion bound
+  -- a template whose agent had that template as a tool would spawn engines
+  until the execution timeout. It now shares `template.invoke`'s cap of 16.
+
 
 - Steps saved with the settings panel's old camelCase keys are no longer
   silently inert. The template builder writes `on_error` / `when` / `as`

--- a/docs/MIGRATION_STATUS.md
+++ b/docs/MIGRATION_STATUS.md
@@ -7,7 +7,7 @@
 | Runtime catalog | 480 modules, 88 categories |
 | Literal module registrations | 487 |
 | Packaged recipes | 41 |
-| Maintained Python source | 971 files, 230,879 lines |
+| Maintained Python source | 971 files, 230,913 lines |
 | Python declarations | 6,035 across 822 files |
 | Static CLI parsers | Generated in `reference/cli.md` |
 | Static HTTP operations | 28 |

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -12,7 +12,7 @@ The current generated runtime catalog contains 480 modules across 88 categories
 and 41 packaged recipes. Catalog search and detail carry each module's
 registry-declared `provides_capability` and `plugin`, never a value derived from
 the module ID. Source traceability covers 971 maintained Python files,
-230,879 lines, and 6,035 class/function/method declarations. These measurements
+230,913 lines, and 6,035 class/function/method declarations. These measurements
 come from checked generators and are not hand-maintained marketing totals.
 
 ## Problem

--- a/docs/reference/source-modules.md
+++ b/docs/reference/source-modules.md
@@ -2,7 +2,7 @@
 
 # Source Module Inventory
 
-Inventory: **971 Python files**, **230,879 lines**, and **6,035 class/function/method declarations**. Test files are covered by the test suite rather than treated as public implementation.
+Inventory: **971 Python files**, **230,913 lines**, and **6,035 class/function/method declarations**. Test files are covered by the test suite rather than treated as public implementation.
 
 | Source module | Lines | Declarations | Import roots | Responsibility |
 |---|---:|---:|---|---|
@@ -488,7 +488,7 @@ Inventory: **971 Python files**, **230,879 lines**, and **6,035 class/function/m
 | [`src/core/modules/atomic/k8s/scale.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/modules/atomic/k8s/scale.py#L1) | 150 | 3 | `asyncio, errors, logging, registry, schema, typing` | Kubernetes Scale Module Scale a Kubernetes deployment to a specified number of replicas |
 | [`src/core/modules/atomic/llm/__init__.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/modules/atomic/llm/__init__.py#L1) | 12 | 0 | `agent, chat, code_fix` | LLM Interaction Modules AI model interaction for code generation, analysis, and autonomous operations |
 | [`src/core/modules/atomic/llm/_agent_tool.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/modules/atomic/llm/_agent_tool.py#L1) | 314 | 11 | `_interfaces, engine, json, logging, registry, typing` | AgentTool Implementation |
-| [`src/core/modules/atomic/llm/_agent_tool_template.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/modules/atomic/llm/_agent_tool_template.py#L1) | 199 | 9 | `_interfaces, asyncio, engine, json, logging, typing` | TemplateAgentTool — Wraps a flyto template as an AI Agent tool. |
+| [`src/core/modules/atomic/llm/_agent_tool_template.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/modules/atomic/llm/_agent_tool_template.py#L1) | 233 | 9 | `_interfaces, asyncio, engine, json, logging, template, typing` | TemplateAgentTool — Wraps a flyto template as an AI Agent tool. |
 | [`src/core/modules/atomic/llm/_chat_models.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/modules/atomic/llm/_chat_models.py#L1) | 339 | 15 | `_interfaces, aiohttp, httpx, json, logging, typing, utils` | ChatModel Implementations |
 | [`src/core/modules/atomic/llm/_interfaces.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/modules/atomic/llm/_interfaces.py#L1) | 118 | 12 | `__future__, dataclasses, typing` | AI Agent Protocol Interfaces |
 | [`src/core/modules/atomic/llm/_prompt.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/modules/atomic/llm/_prompt.py#L1) | 183 | 7 | `core, json, logging, re, typing` | Prompt resolution helpers for LLM Agent module. |

--- a/src/core/modules/atomic/llm/_agent_tool_template.py
+++ b/src/core/modules/atomic/llm/_agent_tool_template.py
@@ -144,18 +144,52 @@ class TemplateAgentTool:
         ctx: Dict,
     ) -> Dict[str, Any]:
         """Execute template via WorkflowEngine."""
-        from ...engine.workflow.engine import WorkflowEngine
+        from ....engine.workflow.engine import WorkflowEngine
+        from ..template.invoke import (
+            _MAX_TEMPLATE_INVOKE_DEPTH,
+            _TEMPLATE_INVOKE_DEPTH_CONTEXT_KEY,
+        )
 
-        # Build workflow definition from template
-        workflow = {
-            "nodes": definition.get("nodes", []),
-            "edges": definition.get("edges", []),
-        }
+        # `steps`, not `nodes`/`edges`. A template definition holds steps --
+        # `template.invoke` builds `workflow={'steps': steps}` from the same
+        # shape -- and the engine answers "No steps defined in workflow" to
+        # anything else. This was unreachable behind the import error above, so
+        # the wrong shape had never once run.
+        steps = definition.get("steps", [])
+        if not steps:
+            return {
+                "ok": False,
+                "error": f"Template has no steps: {self._template_id}",
+            }
+        workflow = {"steps": steps}
+
+        # The recursion cap `template.invoke` enforces, enforced here too. A
+        # template whose agent has that same template as a tool recurses, and
+        # this path had no bound at all: it would spawn engines until the
+        # execution timeout. The counter travels in the child context under the
+        # same key, so a mixed chain -- template.invoke calling an agent whose
+        # tool is a template -- is counted once per level rather than resetting.
+        current_depth = ctx.get(_TEMPLATE_INVOKE_DEPTH_CONTEXT_KEY, 0)
+        if (
+            isinstance(current_depth, bool)
+            or not isinstance(current_depth, int)
+            or current_depth < 0
+        ):
+            return {"ok": False, "error": "Invalid nested template invocation depth"}
+        if current_depth >= _MAX_TEMPLATE_INVOKE_DEPTH:
+            return {
+                "ok": False,
+                "error": (
+                    "Nested template invocation depth exceeds the safe limit "
+                    f"of {_MAX_TEMPLATE_INVOKE_DEPTH}"
+                ),
+            }
 
         # Build initial context — inherit from agent
         initial_context = {
             "execution_id": ctx.get("execution_id"),
             "_agent_depth": ctx.get("_agent_depth", 0),
+            _TEMPLATE_INVOKE_DEPTH_CONTEXT_KEY: current_depth + 1,
         }
 
         # Pass through browser/page context

--- a/tests/modules/test_template_agent_tool.py
+++ b/tests/modules/test_template_agent_tool.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Flyto2. Licensed under Apache-2.0. See LICENSE.
+
+"""The agent's sub-workflow tool, which had never executed once.
+
+`TemplateAgentTool` wraps a stored template as a tool an LLM agent can call --
+flyto's equivalent of n8n's Workflow Tool. Three defects sat on top of each
+other, and only the first was visible:
+
+  1. `_execute_template` imported WorkflowEngine from `...engine`, three levels
+     up from `modules/atomic/llm/`, which is `core.modules.engine` and does not
+     exist. Every neighbour in the same directory writes four. So every call
+     raised ModuleNotFoundError -- and `invoke`'s blanket `except Exception`
+     turned it into `{"ok": False, "error": "..."}`, an ordinary-looking tool
+     failure the agent reported to the model as if the template had run and
+     failed. A crash that never surfaced as a crash.
+
+  2. Behind it, the workflow was built as `{"nodes": ..., "edges": ...}`. A
+     template definition holds `steps`, and the engine answers "No steps
+     defined in workflow" to anything else. The wrong shape had never run.
+
+  3. Behind that, no recursion bound. `template.invoke` caps nesting at 16 and
+     raises past it; this path counted nothing, so a template whose agent has
+     that same template as a tool would spawn engines until the execution
+     timeout.
+
+These tests drive the real tool over the real engine with a real module.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+import core.modules  # noqa: F401,E402
+from core.modules.atomic.llm._agent_tool_template import (  # noqa: E402
+    TemplateAgentTool,
+)
+from core.modules.atomic.template.invoke import (  # noqa: E402
+    _MAX_TEMPLATE_INVOKE_DEPTH,
+    _TEMPLATE_INVOKE_DEPTH_CONTEXT_KEY,
+)
+
+DEFINITION = {
+    "steps": [
+        {"id": "s1", "module": "string.uppercase", "params": {"text": "hi"}},
+    ]
+}
+
+
+def _tool(**context):
+    return TemplateAgentTool(
+        template_id="t1",
+        tool_name="t1",
+        tool_description="a template",
+        parent_context={"template_definitions": {"t1": DEFINITION}, **context},
+    )
+
+
+class TestItRunsAtAll:
+    @pytest.mark.asyncio
+    async def test_the_template_actually_executes(self):
+        """The whole regression in one assertion.
+
+        Before this, every call returned `ok: False` with an import error
+        wearing the clothes of a template that ran and failed.
+        """
+        result = await _tool().invoke({"text": "hi"})
+
+        assert result["ok"] is True
+        steps = result["data"]["steps"]
+        assert steps["s1"]["data"]["result"] == "HI"
+
+    @pytest.mark.asyncio
+    async def test_a_template_with_no_steps_says_so(self):
+        """Rather than reaching the engine and coming back with its wording."""
+        tool = TemplateAgentTool(
+            template_id="empty",
+            tool_name="empty",
+            tool_description="x",
+            parent_context={"template_definitions": {"empty": {"steps": []}}},
+        )
+
+        result = await tool.invoke({})
+
+        assert result["ok"] is False
+        assert "no steps" in result["error"].lower()
+
+
+class TestTheRecursionCapApplies:
+    """`template.invoke` bounds nesting; this path did not.
+
+    The counter travels in the child context under the SAME key, so a mixed
+    chain -- template.invoke calling an agent whose tool is a template -- is
+    counted once per level rather than resetting at each hand-off.
+    """
+
+    @pytest.mark.asyncio
+    async def test_one_below_the_cap_still_runs(self):
+        result = await _tool(
+            **{_TEMPLATE_INVOKE_DEPTH_CONTEXT_KEY: _MAX_TEMPLATE_INVOKE_DEPTH - 1}
+        ).invoke({})
+
+        assert result["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_at_the_cap_it_refuses(self):
+        result = await _tool(
+            **{_TEMPLATE_INVOKE_DEPTH_CONTEXT_KEY: _MAX_TEMPLATE_INVOKE_DEPTH}
+        ).invoke({})
+
+        assert result["ok"] is False
+        assert str(_MAX_TEMPLATE_INVOKE_DEPTH) in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_the_child_is_counted_one_deeper(self):
+        """Without this the cap never arrives: each level would read 0."""
+        result = await _tool().invoke({})
+
+        context = result["data"]["steps"]
+        assert context[_TEMPLATE_INVOKE_DEPTH_CONTEXT_KEY] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", [-1, True, "3", 1.5])
+    async def test_a_depth_that_is_not_a_count_is_refused(self, bad):
+        """`True` is the one worth naming: it is an int in Python and would
+        otherwise pass every comparison as 1."""
+        result = await _tool(**{_TEMPLATE_INVOKE_DEPTH_CONTEXT_KEY: bad}).invoke({})
+
+        assert result["ok"] is False
+        assert "Invalid nested template invocation depth" in result["error"]
+
+
+class TestTheImportIsAtTheRightDepth:
+    """The defect that hid the other two, pinned where it can be seen.
+
+    A relative import one level short resolves to `core.modules.engine`, and
+    the blanket `except Exception` in `invoke` converts the resulting
+    ModuleNotFoundError into an ordinary tool failure -- so the tool reported a
+    template that ran and failed, on every call, for as long as this was wrong.
+    """
+
+    def test_it_imports_from_core_engine_not_core_modules_engine(self):
+        source = Path(
+            "src/core/modules/atomic/llm/_agent_tool_template.py"
+        ).read_text(encoding="utf-8")
+
+        assert "from ....engine.workflow.engine import WorkflowEngine" in source
+        assert "from ...engine.workflow.engine import" not in source


### PR DESCRIPTION
Two things, both prerequisites for releasing 2.31.2.

## The agent's sub-workflow tool had never executed once

`TemplateAgentTool` wraps a stored template as a tool an LLM agent can call — flyto's equivalent of n8n's Workflow Tool. Three defects sat on top of each other, and the top one hid the rest.

**The import was one level short.** `_execute_template` imported WorkflowEngine from `...engine`, which from `modules/atomic/llm/` resolves to `core.modules.engine` and does not exist; every neighbour in the same directory writes four dots. Every call raised ModuleNotFoundError — and `invoke`'s blanket `except Exception` turned it into `{"ok": False, "error": ...}`, an ordinary-looking tool failure. **The agent reported a template that ran and failed.** A crash that never surfaced as a crash.

**Behind it, the wrong shape.** The workflow was built as `{"nodes": ..., "edges": ...}`. A template definition holds `steps` — `template.invoke` builds `workflow={'steps': steps}` from the same shape — and the engine answers "No steps defined in workflow" to anything else.

**Behind that, no recursion bound.** `template.invoke` caps nesting at 16; this path counted nothing, so a template whose agent had that same template as a tool would spawn engines until the execution timeout. It now shares the same context key, so a mixed chain is counted once per level rather than resetting at each hand-off.

Driven against the real engine with a real module:

```
invoke({"text": "hi"})  ->  ok: True, steps.s1.data.result == "HI"
depth 15 -> runs      depth 16 -> refused
depth -1 -> refused   depth True -> refused
```

Ten tests; each of the three fixes severed independently — cutting the import fails all ten, the shape fails three, the cap fails one.

## The changelog

The 2.31.2 section described the old five-valued `verification_status` and stopped there. The ladder — what eleven unreleased commits are about — had never been written down.

**Changed** covers the contract, and why `failed` and `indeterminate` are different answers rather than two words for one: retrying a failure is safe, retrying an indeterminate write may do it twice.

**Fixed** covers nine defects with the measurement rather than an adjective — the revoked webhook that completed green in a shipped recipe, the 158 of 483 modules with no `ok` key, the 3920-pixel scroll reported as a drag, the misspelled selector that reached a green tick 1495ms faster than the real element.

## Verification

Full suite: **5,058 passed**, 4 pre-existing failures (packaging, two live-URL visual-diff tests, version metadata). Three further failures in the first run were network flakes and pass on re-run.

`check_release_drift.py` and `check_documentation.py` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)