### PR TITLE
Add the dedicated Product Verification suite runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,5 @@ tests
 docs
 *.md
 !/README.md
-LICENSE
 .dockerignore
 Dockerfile

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ own the first two layers or hosted product/account logic.
 - Warroom modules infer observable site/action/API/state graphs from evidence;
   they do not own product business logic and do not treat LLM output as a gate.
 - `docs/reference/` is generated from Python AST and repository assets. It maps
-  971 maintained Python files, 6,035 declarations, 487 literal module
+  976 maintained Python files, 6,073 declarations, 487 literal module
   registrations, 28 HTTP operations, 108 environment names, CLI parsers,
   recipes, bundles, and workflows back to source.
 

--- a/Dockerfile.verification
+++ b/Dockerfile.verification
@@ -5,10 +5,10 @@ WORKDIR /build
 
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
-COPY pyproject.toml README.md ./
+COPY pyproject.toml README.md LICENSE NOTICE ./
 COPY src/ src/
 
-RUN pip wheel --no-cache-dir --wheel-dir /wheels .[browser,api]
+RUN pip wheel --no-cache-dir --wheel-dir /wheels .[verification]
 
 # ---- Stage 2: Runtime ----
 FROM python:3.12-slim
@@ -27,7 +27,7 @@ RUN groupadd --gid 1000 flyto \
 WORKDIR /app
 
 COPY --from=builder /wheels /wheels
-RUN pip install --no-cache-dir --no-index --find-links=/wheels flyto-core[browser,api] \
+RUN pip install --no-cache-dir --no-index --find-links=/wheels flyto-core[verification] \
     && rm -rf /wheels
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \

--- a/Dockerfile.verification
+++ b/Dockerfile.verification
@@ -5,7 +5,8 @@ WORKDIR /build
 
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
-COPY pyproject.toml README.md LICENSE NOTICE ./
+COPY pyproject.toml README.md ./
+COPY LICENSE NOTICE ./
 COPY src/ src/
 
 RUN pip wheel --no-cache-dir --wheel-dir /wheels .[verification]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,18 @@
 
 ## Supported Versions
 
-Security fixes land on the latest 2.31.x release. Older lines do not receive
+Security fixes land on the latest 2.32.x release. Older lines do not receive
 backports — upgrading is the supported path.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 2.31.x   | :white_check_mark: |
-| < 2.31   | :x:                |
+| 2.32.x   | :white_check_mark: |
+| < 2.32   | :x:                |
 
-The current release is **2.31.2**. Every advisory published against this
-project is patched at or below **2.29.0**, and every one has a named regression
-test that runs in CI, so `>= 2.29.0` is the floor that clears all of them, while
-`2.31.x` is the line that receives new fixes. Downstream packages should pin the
+The current release is **2.32.0**. Every advisory published against this
+project is patched at or below **2.31.1**, and every one has a named regression
+test that runs in CI, so `>= 2.31.1` is the floor that clears all of them, while
+`2.32.x` is the line that receives new fixes. Downstream packages should pin the
 floor, not the current release; `security/advisories.json` is the
 machine-readable source both numbers are derived from.
 

--- a/SECURITY_STATUS.md
+++ b/SECURITY_STATUS.md
@@ -2,9 +2,9 @@
 
 # Security Status
 
-**Current release: `2.31.2`.** Every advisory published against this project is fixed as of `2.31.1`, and every one has a named regression test that runs in CI.
+**Current release: `2.32.0`.** Every advisory published against this project is fixed as of `2.31.1`, and every one has a named regression test that runs in CI.
 
-Installing `>= 2.31.1` clears every known advisory; `2.31.2` is the supported line and the one that receives fixes. See [`SECURITY.md`](SECURITY.md#supported-versions).
+Installing `>= 2.31.1` clears every known advisory; `2.32.0` is the supported line and the one that receives fixes. See [`SECURITY.md`](SECURITY.md#supported-versions).
 
 39 advisories have been published and fixed (8 critical, 25 high, 6 medium). They are listed here in full, oldest patch first, because the count is less informative than the pattern: almost all of them are two defects — a caller-supplied path reaching a filesystem sink, and a caller-supplied target reaching the network — found one module at a time.
 

--- a/STATE.md
+++ b/STATE.md
@@ -2,6 +2,23 @@
 
 ## Current State
 
+- Product Verification now has versioned suite/case/assertion contracts and
+  authenticated, tenant-scoped runner endpoints. Runs preserve every attempt,
+  enforce deadlines, perform cleanup on cancellation and report explicit
+  blocked/error/not-run outcomes when evidence is unavailable. The bounded
+  runner registry is process-local; Engine owns durable terminal evidence.
+- The `verification` extra and verification service image include PostgreSQL.
+  Database credentials bind to an approved literal address and port; remote
+  TLS verifies the certificate, queries are provisioned and transactions are
+  read-only. HTTP and isolated Chromium share the existing outbound guard.
+- Local verification adapter, lifecycle and network-boundary tests passed.
+  Full non-browser pytest passed 4,708 tests with 65.66% coverage; all 32 focused
+  verification tests and the strict indexer gate passed. Real Engine/Code/Core
+  browser acceptance covers runs, replay, downloads, immutable editor saves,
+  assertion failure, cancellation, and sentinel-preserving cleanup. Package
+  publication and deployed acceptance remain pending. See
+  `docs/verification/acceptance.md`.
+
 - Runtime authority is execution-scoped. A host-created opaque module-policy
   filter can narrow or add the exact stored-template composition capability for
   one execution without changing the process-global default. Nested invocations
@@ -312,7 +329,7 @@
 - The 60% line coverage gate measures the maintained orchestration and
   security-control kernel. Pluggable module implementations and product
   overlays remain covered by catalog, contract, and integration suites.
-- Source-backed documentation now covers 971 maintained Python files, 6,035
+- Source-backed documentation now covers 976 maintained Python files, 6,073
   declarations, 487 literal module registrations, all CLI/HTTP/environment
   surfaces (28 static HTTP operations, 108 environment names), and all
   maintained recipe/workflow assets. CI rejects drift, missing ownership,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -72,7 +72,7 @@ evidence but does not decide the gate.
 
 - [All 480 active module schemas](TOOL_CATALOG.md)
 - [All 487 literal module implementations](reference/registered-modules.md)
-- [All 6,035 maintained Python declarations](reference/python-api.md)
+- [All 6,073 maintained Python declarations](reference/python-api.md)
 - [All CLI parsers](reference/cli.md)
 - [All HTTP decorators](reference/http-api.md)
 - [All environment readers and packaged workflow assets](reference/configuration.md)

--- a/docs/MIGRATION_STATUS.md
+++ b/docs/MIGRATION_STATUS.md
@@ -7,8 +7,8 @@
 | Runtime catalog | 480 modules, 88 categories |
 | Literal module registrations | 487 |
 | Packaged recipes | 41 |
-| Maintained Python source | 971 files, 230,925 lines |
-| Python declarations | 6,035 across 822 files |
+| Maintained Python source | 976 files, 231,535 lines |
+| Python declarations | 6,073 across 826 files |
 | Static CLI parsers | Generated in `reference/cli.md` |
 | Static HTTP operations | 28 |
 | Environment-variable names | 108 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,10 @@ and emits evidence. The repo-local role contract is [`flyto-product.toml`](../fl
 - [CLI](CLI.md): supported commands and operational behavior.
 - [HTTP And MCP API](API.md): routes, authentication, errors, and mount status.
 - [Configuration](CONFIGURATION.md): extras, policy, environment, and local state.
+- [Product Verification](verification/platform-research.md): suite lifecycle,
+  adapter scope, packaging and evidence contracts.
+- [Verification Acceptance](verification/acceptance.md): controlled cross-layer
+  execution evidence and remaining release gates.
 
 ## Build Workflows
 
@@ -65,7 +69,7 @@ The generated layer makes source coverage auditable without turning narrative
 guides into hand-maintained symbol dumps:
 
 - 480 active runtime modules across 88 catalog categories.
-- 971 maintained Python files and 6,035 declarations.
+- 976 maintained Python files and 6,073 declarations.
 - 487 literal module registrations linked to source.
 - every static CLI parser and HTTP decorator.
 - 108 environment-variable readers.

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -11,8 +11,8 @@ local HTTP Execution API, packaged recipes, evidence capture, and replay.
 The current generated runtime catalog contains 480 modules across 88 categories
 and 41 packaged recipes. Catalog search and detail carry each module's
 registry-declared `provides_capability` and `plugin`, never a value derived from
-the module ID. Source traceability covers 971 maintained Python files,
-230,925 lines, and 6,035 class/function/method declarations. These measurements
+the module ID. Source traceability covers 976 maintained Python files,
+231,535 lines, and 6,073 class/function/method declarations. These measurements
 come from checked generators and are not hand-maintained marketing totals.
 
 ## Problem

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -2,7 +2,7 @@
 
 # Python Declaration Reference
 
-Every class, function, nested function, and method in maintained runtime, CLI, script, example, and plugin-template sources: **6,035 declarations across 822 files**.
+Every class, function, nested function, and method in maintained runtime, CLI, script, example, and plugin-template sources: **6,073 declarations across 826 files**.
 
 ## `demo.py`
 
@@ -10117,6 +10117,64 @@ Every class, function, nested function, and method in maintained runtime, CLI, s
 | function | `def _detect_cycles(node_ids: Set&#91;str&#93;, outgoing: Dict&#91;str, List&#91;str&#93;&#93;, node_map: Dict&#91;str, Dict&#91;str, Any&#93;&#93;) -> List&#91;WorkflowError&#93;` | Detect cycles in the workflow graph using DFS | [`src/core/validation/workflow.py:461`](https://github.com/flytohub/flyto-core/blob/main/src/core/validation/workflow.py#L461) |
 | method | `def _detect_cycles.dfs(node: str) -> bool` | Returns True if cycle found | [`src/core/validation/workflow.py:484`](https://github.com/flytohub/flyto-core/blob/main/src/core/validation/workflow.py#L484) |
 
+## `src/core/verification/adapters.py`
+
+| Kind | Signature | Responsibility | Source |
+|---|---|---|---|
+| class | `class Connection` | Defines the Connection runtime contract. | [`src/core/verification/adapters.py:29`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L29) |
+| function | `def substitute(value, context)` | Implements `substitute`; linked source is authoritative. | [`src/core/verification/adapters.py:38`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L38) |
+| function | `def redact(value, secrets=())` | Implements `redact`; linked source is authoritative. | [`src/core/verification/adapters.py:50`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L50) |
+| function | `def database_connection_options(connection: Connection) -> dict` | Bind credentials to an approved literal address without a second DNS lookup. | [`src/core/verification/adapters.py:64`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L64) |
+| class | `class Adapters` | One runner invocation owns all browser contexts and connection bindings. | [`src/core/verification/adapters.py:99`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L99) |
+| method | `def Adapters.__init__(self, connections: dict&#91;str, Connection&#93;)` | Implements `Adapters.__init__`; linked source is authoritative. | [`src/core/verification/adapters.py:101`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L101) |
+| method | `async def Adapters.__call__(self, step: Step, context: dict) -> dict` | Implements `Adapters.__call__`; linked source is authoritative. | [`src/core/verification/adapters.py:104`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L104) |
+| method | `async def Adapters.http(self, connection: Connection, params: dict, url: str) -> dict` | Implements `Adapters.http`; linked source is authoritative. | [`src/core/verification/adapters.py:129`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L129) |
+| method | `async def Adapters.postgres(self, connection: Connection, params: dict, step: Step) -> dict` | Implements `Adapters.postgres`; linked source is authoritative. | [`src/core/verification/adapters.py:151`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L151) |
+| method | `async def Adapters.web(self, connection: Connection, params: dict, url: str, step: Step) -> dict` | Implements `Adapters.web`; linked source is authoritative. | [`src/core/verification/adapters.py:174`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L174) |
+| method | `async def Adapters.web.guard(route)` | Implements `Adapters.web.guard`; linked source is authoritative. | [`src/core/verification/adapters.py:192`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L192) |
+
+## `src/core/verification/contracts.py`
+
+| Kind | Signature | Responsibility | Source |
+|---|---|---|---|
+| class | `class Contract(BaseModel)` | Defines the Contract runtime contract. | [`src/core/verification/contracts.py:14`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L14) |
+| class | `class Assertion(Contract)` | Defines the Assertion runtime contract. | [`src/core/verification/contracts.py:18`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L18) |
+| class | `class Step(Contract)` | Defines the Step runtime contract. | [`src/core/verification/contracts.py:25`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L25) |
+| class | `class Case(Contract)` | Defines the Case runtime contract. | [`src/core/verification/contracts.py:34`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L34) |
+| method | `def Case.unique_steps(self)` | Implements `Case.unique_steps`; linked source is authoritative. | [`src/core/verification/contracts.py:47`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L47) |
+| class | `class Suite(Contract)` | Defines the Suite runtime contract. | [`src/core/verification/contracts.py:56`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L56) |
+| method | `def Suite.ordered_dependencies(self)` | Implements `Suite.ordered_dependencies`; linked source is authoritative. | [`src/core/verification/contracts.py:65`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L65) |
+| function | `def digest(value: Any) -> str` | Implements `digest`; linked source is authoritative. | [`src/core/verification/contracts.py:76`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L76) |
+| function | `def observe(data: Any, path: str) -> tuple&#91;bool, Any&#93;` | Resolve an explicit JSON pointer without expression evaluation. | [`src/core/verification/contracts.py:80`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L80) |
+| function | `def evaluate(assertion: Assertion, observation: dict) -> dict` | Implements `evaluate`; linked source is authoritative. | [`src/core/verification/contracts.py:93`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L93) |
+
+## `src/core/verification/runtime.py`
+
+| Kind | Signature | Responsibility | Source |
+|---|---|---|---|
+| class | `class BlockedError(Exception)` | The operation cannot execute inside the approved environment. | [`src/core/verification/runtime.py:16`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/runtime.py#L16) |
+| function | `def now() -> str` | Implements `now`; linked source is authoritative. | [`src/core/verification/runtime.py:20`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/runtime.py#L20) |
+| function | `def verdict(outcomes: list&#91;str&#93;) -> str` | Implements `verdict`; linked source is authoritative. | [`src/core/verification/runtime.py:24`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/runtime.py#L24) |
+| function | `async def run_step(step: Step, phase: str, attempt: int, context: dict, call: AdapterCall) -> dict` | Implements `run_step`; linked source is authoritative. | [`src/core/verification/runtime.py:33`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/runtime.py#L33) |
+| function | `async def interruptible_step(step, phase, attempt, context, call, remaining, cancel)` | Implements `interruptible_step`; linked source is authoritative. | [`src/core/verification/runtime.py:58`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/runtime.py#L58) |
+| function | `async def execute_suite(suite: Suite, environment: dict, call: AdapterCall, *, run_id: str \| None=None, cancel: asyncio.Event \| None=None, progress: Callable&#91;&#91;dict&#93;, None&#93; \| None=None) -> dict` | Every run gets a fresh result graph, including not-run cases and teardown evidence. | [`src/core/verification/runtime.py:76`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/runtime.py#L76) |
+
+## `src/core/verification/service.py`
+
+| Kind | Signature | Responsibility | Source |
+|---|---|---|---|
+| function | `def prune_records(records, *, reserve=False)` | Implements `prune_records`; linked source is authoritative. | [`src/core/verification/service.py:26`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L26) |
+| function | `async def adapter_readiness()` | Implements `adapter_readiness`; linked source is authoritative. | [`src/core/verification/service.py:35`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L35) |
+| function | `def failed_result(body, partial)` | Implements `failed_result`; linked source is authoritative. | [`src/core/verification/service.py:47`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L47) |
+| class | `class SuiteRunRequest(Contract)` | Defines the SuiteRunRequest runtime contract. | [`src/core/verification/service.py:61`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L61) |
+| function | `def mount_suite_routes(app, authenticate)` | Implements `mount_suite_routes`; linked source is authoritative. | [`src/core/verification/service.py:70`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L70) |
+| method | `def mount_suite_routes.owned(run_id, org_id, project_id)` | Implements `mount_suite_routes.owned`; linked source is authoritative. | [`src/core/verification/service.py:74`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L74) |
+| method | `async def mount_suite_routes.capabilities()` | Implements `mount_suite_routes.capabilities`; linked source is authoritative. | [`src/core/verification/service.py:82`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L82) |
+| method | `async def mount_suite_routes.submit(body: SuiteRunRequest)` | Implements `mount_suite_routes.submit`; linked source is authoritative. | [`src/core/verification/service.py:93`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L93) |
+| method | `async def mount_suite_routes.submit.work()` | Implements `mount_suite_routes.submit.work`; linked source is authoritative. | [`src/core/verification/service.py:112`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L112) |
+| method | `async def mount_suite_routes.read(run_id: str, org_id: str, project_id: str)` | Implements `mount_suite_routes.read`; linked source is authoritative. | [`src/core/verification/service.py:127`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L127) |
+| method | `async def mount_suite_routes.cancel(run_id: str, org_id: str, project_id: str)` | Implements `mount_suite_routes.cancel`; linked source is authoritative. | [`src/core/verification/service.py:132`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L132) |
+
 ## `src/core/verification_service.py`
 
 | Kind | Signature | Responsibility | Source |
@@ -10147,4 +10205,4 @@ Every class, function, nested function, and method in maintained runtime, CLI, s
 | method | `async def create_app.health()` | Implements `create_app.health`; linked source is authoritative. | [`src/core/verification_service.py:443`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification_service.py#L443) |
 | method | `async def create_app.run(body: VerificationRunRequest, _: None=Depends(require_run_auth))` | Implements `create_app.run`; linked source is authoritative. | [`src/core/verification_service.py:447`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification_service.py#L447) |
 | method | `async def create_app.run._execute_with_fixed_id() -> None` | Implements `create_app.run._execute_with_fixed_id`; linked source is authoritative. | [`src/core/verification_service.py:451`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification_service.py#L451) |
-| function | `def main(host: str='127.0.0.1', port: int=8344) -> None` | Implements `main`; linked source is authoritative. | [`src/core/verification_service.py:468`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification_service.py#L468) |
+| function | `def main(host: str='127.0.0.1', port: int=8344) -> None` | Implements `main`; linked source is authoritative. | [`src/core/verification_service.py:471`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification_service.py#L471) |

--- a/docs/reference/source-modules.md
+++ b/docs/reference/source-modules.md
@@ -2,7 +2,7 @@
 
 # Source Module Inventory
 
-Inventory: **971 Python files**, **230,925 lines**, and **6,035 class/function/method declarations**. Test files are covered by the test suite rather than treated as public implementation.
+Inventory: **976 Python files**, **231,535 lines**, and **6,073 class/function/method declarations**. Test files are covered by the test suite rather than treated as public implementation.
 
 | Source module | Lines | Declarations | Import roots | Responsibility |
 |---|---:|---:|---|---|
@@ -975,5 +975,10 @@ Inventory: **971 Python files**, **230,925 lines**, and **6,035 class/function/m
 | [`src/core/validation/errors.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/validation/errors.py#L1) | 159 | 2 | `dataclasses, typing` | Unified Error Codes for Validation |
 | [`src/core/validation/index.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/validation/index.py#L1) | 175 | 8 | `modules, threading, typing` | Connection Index |
 | [`src/core/validation/workflow.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/validation/workflow.py#L1) | 514 | 10 | `connection, dataclasses, errors, index, modules, typing` | Workflow Validation API |
-| [`src/core/verification_service.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification_service.py#L1) | 476 | 27 | `__future__, aiohttp, asyncio, base64, core, dataclasses, fastapi, fnmatch, hashlib, hmac, json, logging` | Flyto2 deterministic verification runner service. |
+| [`src/core/verification/__init__.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/__init__.py#L1) | 1 | 0 | `none` | Versioned adapter contracts for the existing deterministic verification runner. |
+| [`src/core/verification/adapters.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/adapters.py#L1) | 224 | 11 | `__future__, asyncio, asyncpg, contracts, core, dataclasses, ipaddress, json, playwright, re, runtime, ssl` | HTTP, PostgreSQL and Chromium adapters for operator-provisioned connections. |
+| [`src/core/verification/contracts.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/contracts.py#L1) | 100 | 10 | `__future__, hashlib, json, pydantic, typing` | Bounded, executable test definitions; credentials never belong in this model. |
+| [`src/core/verification/runtime.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/runtime.py#L1) | 145 | 6 | `__future__, asyncio, contextlib, contracts, datetime, time, typing, uuid` | Deterministic suite execution with attempt-local evidence and bounded cleanup. |
+| [`src/core/verification/service.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification/service.py#L1) | 137 | 11 | `__future__, adapters, asyncio, contracts, fastapi, importlib, pathlib, playwright, pydantic, runtime, time, typing` | Suite execution routes mounted on the existing authenticated runner app. |
+| [`src/core/verification_service.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/core/verification_service.py#L1) | 479 | 27 | `__future__, aiohttp, asyncio, base64, core, dataclasses, fastapi, fnmatch, hashlib, hmac, json, logging` | Flyto2 deterministic verification runner service. |
 | [`src/recipes/__init__.py:1`](https://github.com/flytohub/flyto-core/blob/main/src/recipes/__init__.py#L1) | 1 | 0 | `none` | Implementation module; linked source is authoritative. |

--- a/docs/verification/acceptance.md
+++ b/docs/verification/acceptance.md
@@ -1,0 +1,69 @@
+# Local acceptance evidence
+
+Candidate validation on 2026-09-06:
+
+- Existing verification service tests: 9 passed, including the regression that
+  workflow completion without an evidence pack must be blocked.
+- New bounded suite runtime contracts: 13 passed.
+- Real controlled adapter integration: 1 passed. Two separate runs issued an
+  HTTP POST into an isolated PostgreSQL fixture, queried the persisted state in
+  a read-only transaction, opened Chromium and asserted the rendered state,
+  then deleted only the attempt-namespaced row through the fixture API.
+- Both runs preserved an unrelated sentinel row. A provisioned DELETE query
+  was rejected by PostgreSQL read-only mode and left that row intact.
+
+Command:
+
+```sh
+FLYTO_PV_FIXTURE_PG_URL=<disposable-postgres-dsn> python -m pytest \
+  tests/verification/test_local_adapters.py -o addopts='' -q
+```
+
+The fixture report is written under pytest's per-test temporary directory and
+includes run IDs, version digests, assertions, observations, teardown and timing
+receipts.
+
+## Cross-layer browser acceptance
+
+Controlled local acceptance also exercised Code through the real Engine router,
+encrypted test credential storage, the dedicated authenticated Core service,
+PostgreSQL, and Chromium. Browser actions started a real suite, downloaded its
+accepted report, and reran it with a distinct run ID and retained parent ID.
+Environment and suite edits saved immutable version 2 without exposing stored
+credentials. Desktop, tablet, and phone viewports were inspected.
+
+An intentionally incorrect database assertion remained a failed result and
+still cleaned up its attempt data. Browser cancellation acknowledged the
+request, interrupted a slow HTTP step, completed cleanup, and persisted a
+cancelled result. Every check preserved the unrelated sentinel row.
+
+The full non-browser Core suite passed 4,708 tests with 220 skips and 443
+browser-marker exclusions; coverage was 65.66% against the required 60%.
+All 32 focused verification tests, Ruff, the strict indexer gate (19 checks),
+and task validation passed. Base dependency auditing found no known
+vulnerabilities. The canonical Python 3.11 lock regeneration resolves lxml
+6.1.3, the version already present in the full-suite test environment.
+
+These are local source and integration results. They do not claim a merged
+release, a published package, staging readiness, or production deployment.
+
+## Dedicated Cloud Run deployment
+
+The service image is built from an explicit Core commit with
+`Dockerfile.verification`, including the distribution license files. The
+verification extra supplies HTTP, PostgreSQL and Chromium dependencies. Deploy
+it separately from the legacy `flyto-runner`; `/suite-capabilities` must report
+the adapters from this image before Engine is configured to use it.
+
+Cloud Run remains private. A dedicated runtime service account receives access
+only to its application secret, and the Engine service identity receives the
+Invoker role on this service. Engine sends its Google identity token plus
+`X-Internal-Key`. Configure the same Secret Manager version through
+`FLYTO_VERIFICATION_SECRET` on both services; never write its value into a
+manifest or release report.
+
+Set the service maximum to one instance and keep CPU available between requests:
+active suite state is process-local. Engine polls for progress and retains
+terminal evidence. A restart remains an observable error/timeout, not a success.
+Production deployment does not enable the isolated-fixture development flags
+or execute any customer suite by itself.

--- a/docs/verification/platform-research.md
+++ b/docs/verification/platform-research.md
@@ -1,0 +1,51 @@
+# Product Verification platform decisions
+
+Research date: 2026-09-06. Candidate source: `fb42fcd4ce0f54f47708a1559ec475725fa0083d`.
+The installed validation environment uses Python 3.12, asyncpg 0.31.0 and
+Playwright Python 1.62.0. These are observed installed versions, not a claim
+that all other versions or protocols are supported.
+
+| User problem | Direct source and version | Adopted contract / acceptance | Limits and rejected alternative |
+| --- | --- | --- | --- |
+| A screenshot or completed request can hide a failed business condition | [Playwright Python assertions](https://playwright.dev/python/docs/test-assertions), current docs read 2026-09-06 | Required, typed machine assertions; poll Web observations until the assertion deadline; missing fields fail | No AI pass authority; no fixed sleep as success evidence |
+| Retrying hides the first failure or contaminates browser state | [Playwright retries](https://playwright.dev/docs/test-retries), [browser-context implementation guide](https://github.com/microsoft/playwright/blob/main/docs/src/browser-contexts.md) | Fresh context for each Web step, unique run/case/attempt identity, retain every attempt; retries require explicit retry-safe declaration | The Python library is not the Playwright Test runner. We implement lifecycle receipts and do not claim its reporter semantics |
+| Reports lose evidence from the original failure | [Playwright issue 34588](https://github.com/microsoft/playwright/issues/34588), discussion read 2026-09-06 | Keep initial failure and later attempts separately; compare runs by version and case IDs | Issue is a requirement lead, not proof of a shipped feature. Raw traces can contain secrets; do not automatically publish them |
+| Database assertions accidentally change customer data | [PostgreSQL 18 SET TRANSACTION](https://www.postgresql.org/docs/18/sql-set-transaction.html), [asyncpg 0.31.0 transaction source](https://github.com/MagicStack/asyncpg/blob/v0.31.0/asyncpg/transaction.py) | Operator-approved parameterized query IDs, readonly transaction, bounded result rows and deadlines; write rejection must be demonstrated against PostgreSQL | READ ONLY is not a universal side-effect sandbox. Reject arbitrary SQL and use a restricted database principal; SQLite, MySQL and arbitrary stored functions are not supported |
+| Cancellation leaks a connection or hangs a run | [asyncpg API](https://magicstack.github.io/asyncpg/current/api/index.html), [issue 547](https://github.com/MagicStack/asyncpg/issues/547), [asyncpg releases](https://github.com/MagicStack/asyncpg/releases) | Close connections in finally with a bounded close timeout; test cancellation and timeout against the installed version | The issue describes 0.20.1 and does not prove a defect in 0.31.0. No shared connection pool in this first adapter |
+| Runner logs cannot be connected to a report | [OpenTelemetry CI/CD conventions](https://opentelemetry.io/docs/specs/semconv/cicd/) (Release Candidate when read) | Stable run, suite version, environment version, runner and evidence digest in every report | Keep the Flyto2 result schema versioned. Do not adopt an unstable external enum as our public contract or add a telemetry backend to this module |
+
+## UX consequences
+
+The module navigation follows suites, runs, environments/connections, runners,
+and reports. Adapter selection belongs in the case editor. A failed assertion
+shows its source step, expected value and redacted observation. A rerun retains
+its parent reference and never overwrites the previous evidence. A transport
+success only means the runner accepted the work.
+
+## Initial capability envelope
+
+- HTTP/HTTPS JSON observations, with guarded DNS resolution and no redirects.
+- PostgreSQL queries selected from operator-provisioned connection bindings.
+  The endpoint is a literal IP address and port; the credential DSN must match
+  both and cannot override them through query options. Non-isolated connections
+  require TLS certificate verification against the approved IP. Hostname-only
+  database targets are blocked until a resolver can preserve both address
+  pinning and certificate hostname verification. Private targets require the
+  trusted host's explicit isolated binding; metadata addresses remain denied.
+- Chromium Web observations against isolated IP-bound fixtures. DNS-named Web
+  environments require a production egress proxy before they can be admitted.
+- Cross-layer flows compose those same adapters; no additional task system.
+- API writes require an isolated connection and the attempt namespace in the
+  request. Cleanup uses the same restriction.
+
+Every capability above remains a candidate until its acceptance evidence is
+recorded in the handoff. A library's documented support is not Flyto2 support.
+
+## Runner packaging and lifecycle
+
+Install `flyto-core[verification]` for the HTTP, PostgreSQL and Chromium service.
+The service reports each installed adapter separately; missing dependencies or
+Chromium produce degraded readiness. Four active tasks and 1,000 retained
+records bound the process registry. Terminal records expire after an hour.
+The Engine persists terminal evidence independently and converts an unavailable
+execution into a bounded error/timeout; a process restart is never a pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,8 +128,12 @@ jsast = [
 cloud = [
     "flyto-core[browser,image]",
 ]
+verification = [
+    "flyto-core[browser,api]",
+    "asyncpg>=0.31.0,<0.32",
+]
 all = [
-    "flyto-core[browser,api,vector,telegram,image,crypto,dns,ai,jsast]",
+    "flyto-core[browser,api,vector,telegram,image,crypto,dns,ai,jsast,verification]",
 ]
 dev = [
     "flyto-core[api]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flyto-core"
-version = "2.31.2"
+version = "2.32.0"
 description = "The open-source execution engine for AI agents. 480 modules, MCP-native, triggers, queue, versioning, metering."
 readme = "README.md"
 license = "Apache-2.0"

--- a/requirements.lock
+++ b/requirements.lock
@@ -24,7 +24,7 @@ frozenlist==1.8.0
     #   aiosignal
 idna==3.19
     # via yarl
-lxml==6.1.2
+lxml==6.1.3
     # via flyto-core (pyproject.toml)
 multidict==6.7.1
     # via

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/flytohub/flyto-core",
     "source": "github"
   },
-  "version": "2.31.2",
+  "version": "2.32.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "flyto-core",
-      "version": "2.31.2",
+      "version": "2.32.0",
       "runtimeHint": "pip",
       "transport": {
         "type": "stdio"

--- a/src/core/verification/__init__.py
+++ b/src/core/verification/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned adapter contracts for the existing deterministic verification runner."""

--- a/src/core/verification/adapters.py
+++ b/src/core/verification/adapters.py
@@ -1,0 +1,224 @@
+"""HTTP, PostgreSQL and Chromium adapters for operator-provisioned connections.
+
+Connection bindings are injected by the trusted runner host after tenant,
+project and environment admission. Suite inputs cannot choose credentials or
+expand network scope. No arbitrary JavaScript, shell, or SQL mutation adapter
+is exposed.
+"""
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import re
+import ssl
+from dataclasses import dataclass, field
+from urllib.parse import parse_qs, unquote, urljoin, urlsplit
+
+from core.utils import (
+    guarded_client_session,
+    trusted_outbound_network_scope,
+    validate_url_with_env_config,
+)
+
+from .contracts import Step, evaluate
+from .runtime import BlockedError
+
+
+@dataclass(frozen=True)
+class Connection:
+    adapter: str
+    endpoint: str
+    isolated: bool = False
+    headers: dict = field(default_factory=dict, repr=False)
+    database_dsn: str = field(default='', repr=False)
+    queries: dict[str, str] = field(default_factory=dict)
+
+
+def substitute(value, context):
+    if isinstance(value, str):
+        for key in ('run_id', 'attempt_id', 'case_id'):
+            value = value.replace('{{' + key + '}}', str(context[key]))
+        return value
+    if isinstance(value, list):
+        return [substitute(v, context) for v in value]
+    if isinstance(value, dict):
+        return {k: substitute(v, context) for k, v in value.items()}
+    return value
+
+
+def redact(value, secrets=()):
+    if isinstance(value, dict):
+        return {k: '[redacted]' if re.search('password|secret|token|authorization|cookie|api.?key', k, re.I)
+                else redact(v, secrets) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact(v, secrets) for v in value]
+    if isinstance(value, str):
+        for secret in secrets:
+            if secret:
+                value = value.replace(secret, '[redacted]')
+        return value[:8192]
+    return value
+
+
+def database_connection_options(connection: Connection) -> dict:
+    """Bind credentials to an approved literal address without a second DNS lookup.
+
+    Remote connections require certificate verification against that address.
+    DSN query options cannot replace the host, service, credentials or TLS policy.
+    """
+    try:
+        endpoint, dsn = urlsplit(connection.endpoint), urlsplit(connection.database_dsn)
+        if (endpoint.scheme not in ('postgres', 'postgresql') or dsn.scheme not in ('postgres', 'postgresql')
+                or endpoint.username or endpoint.password or endpoint.query or endpoint.fragment or dsn.fragment):
+            raise ValueError('invalid database endpoint')
+        address = ipaddress.ip_address(endpoint.hostname)
+        if dsn.hostname != endpoint.hostname or (dsn.port or 5432) != (endpoint.port or 5432):
+            raise ValueError('database credential scope mismatch')
+        options = parse_qs(dsn.query, keep_blank_values=True, strict_parsing=True)
+        if set(options) - {'sslmode'} or any(len(value) != 1 for value in options.values()):
+            raise ValueError('unsupported database connection options')
+        mode = options.get('sslmode', ['verify-full' if not connection.isolated else 'disable'])[0]
+        if mode not in ('disable', 'verify-full') or (mode == 'disable' and not connection.isolated):
+            raise ValueError('database TLS verification required')
+        if not dsn.username or not dsn.path.strip('/'):
+            raise ValueError('explicit database and user required')
+        host = str(address)
+        authority = '[' + host + ']' if address.version == 6 else host
+        port = endpoint.port or 5432
+        with trusted_outbound_network_scope(allowed_hosts=[host], allowed_ports=[port],
+                                            allow_private_targets=connection.isolated):
+            validate_url_with_env_config(f'http://{authority}:{port}/')
+        return {'host': host, 'port': port, 'user': unquote(dsn.username),
+                'password': unquote(dsn.password or ''), 'database': unquote(dsn.path[1:]),
+                'ssl': ssl.create_default_context() if mode == 'verify-full' else False}
+    except Exception as exc:
+        raise BlockedError() from exc
+
+
+class Adapters:
+    """One runner invocation owns all browser contexts and connection bindings."""
+    def __init__(self, connections: dict[str, Connection]):
+        self.connections = connections
+
+    async def __call__(self, step: Step, context: dict) -> dict:
+        connection = self.connections.get(step.connection)
+        if connection is None or connection.adapter != step.adapter:
+            raise BlockedError()
+        params = substitute(step.input, context)
+        if step.adapter == 'postgres':
+            return await self.postgres(connection, params, step)
+        target = urlsplit(connection.endpoint)
+        if target.scheme not in ('http', 'https') or target.username or target.password:
+            raise BlockedError()
+        path = params.get('path', '/')
+        url = urljoin(connection.endpoint.rstrip('/') + '/', path)
+        if urlsplit(url).netloc != target.netloc or urlsplit(url).scheme != target.scheme:
+            raise BlockedError()
+        with trusted_outbound_network_scope(allowed_hosts=[target.hostname],
+                allowed_ports=[target.port or (443 if target.scheme == 'https' else 80)],
+                allow_private_targets=connection.isolated):
+            if step.adapter == 'http':
+                if params.get('method', 'GET').upper() not in ('GET', 'HEAD') and context['attempt_id'] not in json.dumps(params):
+                    raise BlockedError()
+                observation = await self.http(connection, params, url)
+            else:
+                observation = await self.web(connection, params, url, step)
+        return redact(observation, tuple(connection.headers.values()))
+
+    async def http(self, connection: Connection, params: dict, url: str) -> dict:
+        method = params.get('method', 'GET').upper()
+        if method not in ('GET', 'HEAD') and not connection.isolated:
+            raise BlockedError()
+        if method not in ('GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'):
+            raise BlockedError()
+        async with guarded_client_session() as session:  # noqa: SIM117
+            async with session.request(method, url, json=params.get('json'),
+                    headers=connection.headers, allow_redirects=False) as response:
+                body = await response.content.read(65537)
+                if len(body) > 65536:
+                    raise BlockedError()
+                try:
+                    data = json.loads(body)
+                    text = json.dumps(redact(data, tuple(connection.headers.values())), ensure_ascii=False)
+                except (ValueError, UnicodeDecodeError):
+                    data = None
+                    text = body.decode('utf-8', errors='replace')
+                return {'status': response.status, 'body': data,
+                        'text': text[:8192],
+                        'request': {'method': method, 'path': urlsplit(url).path}}
+
+    async def postgres(self, connection: Connection, params: dict, step: Step) -> dict:
+        # Query text is provisioned with the connection by an operator. Users
+        # select its ID and bound values; a SELECT prefix is not an SQL sandbox.
+        query = connection.queries.get(params.get('query_id', ''))
+        if not query or not connection.database_dsn:
+            raise BlockedError()
+        import asyncpg
+        options = database_connection_options(connection)
+        conn = await asyncpg.connect(**options, timeout=step.timeout_ms / 1000,
+                                     command_timeout=step.timeout_ms / 1000)
+        try:
+            async with conn.transaction(readonly=True):
+                statement = await conn.prepare(query)
+                rows = []
+                async for record in statement.cursor(*params.get('arguments', []), prefetch=100):
+                    rows.append(dict(record))
+                    if len(rows) > 100:
+                        raise BlockedError()
+                return redact({'rows': rows, 'row_count': len(rows), 'query_id': params['query_id'],
+                               'transaction_read_only': True}, [connection.database_dsn])
+        finally:
+            await conn.close(timeout=2)
+
+    async def web(self, connection: Connection, params: dict, url: str, step: Step) -> dict:
+        from playwright.async_api import async_playwright
+
+        from core.utils import validate_url_with_env_config
+        if params.get('actions') and not connection.isolated:
+            raise BlockedError()
+        # DNS-named Web targets require a production browser egress proxy.
+        if not connection.isolated:
+            raise BlockedError()
+        try:
+            ipaddress.ip_address(urlsplit(url).hostname)
+        except ValueError as exc:
+            raise BlockedError() from exc
+        validate_url_with_env_config(url)
+        async with async_playwright() as pw:
+            browser = await pw.chromium.launch(headless=True)
+            context = await browser.new_context(service_workers='block', extra_http_headers=connection.headers)
+            try:
+                async def guard(route):
+                    request_url = route.request.url
+                    try:
+                        if urlsplit(request_url).netloc != urlsplit(url).netloc:
+                            raise BlockedError()
+                        validate_url_with_env_config(request_url)
+                    except Exception:
+                        await route.abort()
+                    else:
+                        await route.continue_()
+                await context.route('**/*', guard)
+                page = await context.new_page()
+                await page.goto(url, wait_until='domcontentloaded', timeout=step.timeout_ms)
+                for action in params.get('actions', [])[:20]:
+                    locator = page.get_by_role(action['role'], name=action['name'], exact=True)
+                    if action['action'] == 'click':
+                        await locator.click(timeout=step.timeout_ms)
+                    elif action['action'] == 'fill':
+                        await locator.fill(action['value'], timeout=step.timeout_ms)
+                    else:
+                        raise BlockedError()
+                locator = page.locator(params.get('selector', 'body'))
+                # Poll the observable assertion, not an arbitrary settle delay.
+                for _ in range(max(1, step.timeout_ms // 100)):
+                    observation = {'text': await locator.inner_text(timeout=step.timeout_ms),
+                                   'count': await locator.count(), 'url': page.url}
+                    if all(evaluate(a, observation)['outcome'] == 'pass' for a in step.assertions):
+                        break
+                    await asyncio.sleep(0.1)
+                return observation
+            finally:
+                await context.close()
+                await browser.close()

--- a/src/core/verification/contracts.py
+++ b/src/core/verification/contracts.py
@@ -1,0 +1,100 @@
+"""Bounded, executable test definitions; credentials never belong in this model."""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+Outcome = Literal['pass', 'fail', 'error', 'blocked', 'skipped', 'cancelled', 'timeout', 'not-run']
+Adapter = Literal['http', 'postgres', 'web']
+
+
+class Contract(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+
+class Assertion(Contract):
+    id: str = Field(min_length=1, max_length=80)
+    path: str = Field(min_length=1, max_length=256)
+    operator: Literal['equals', 'contains', 'exists'] = 'equals'
+    expected: Any = None
+
+
+class Step(Contract):
+    id: str = Field(min_length=1, max_length=80)
+    adapter: Adapter
+    connection: str = Field(min_length=1, max_length=80)
+    input: dict[str, Any] = Field(default_factory=dict)
+    assertions: list[Assertion] = Field(min_length=1, max_length=30)
+    timeout_ms: int = Field(default=10000, ge=10, le=60000)
+
+
+class Case(Contract):
+    id: str = Field(min_length=1, max_length=80)
+    name: str = Field(min_length=1, max_length=200)
+    version: int = Field(default=1, ge=1)
+    depends_on: list[str] = Field(default_factory=list, max_length=30)
+    preconditions: list[Step] = Field(default_factory=list, max_length=10)
+    steps: list[Step] = Field(min_length=1, max_length=30)
+    cleanup: list[Step] = Field(default_factory=list, max_length=10)
+    retries: int = Field(default=0, ge=0, le=2)
+    retry_safe: bool = False
+    skipped: bool = False
+
+    @model_validator(mode='after')
+    def unique_steps(self):
+        ids = [s.id for s in self.preconditions + self.steps + self.cleanup]
+        if len(ids) != len(set(ids)):
+            raise ValueError('step IDs must be unique within a case')
+        if self.retries and not self.retry_safe:
+            raise ValueError('retries require an explicitly retry-safe case')
+        return self
+
+
+class Suite(Contract):
+    schema_version: Literal['flyto.product-verification.suite.v1'] = 'flyto.product-verification.suite.v1'
+    id: str = Field(min_length=1, max_length=80)
+    name: str = Field(min_length=1, max_length=200)
+    version: int = Field(default=1, ge=1)
+    cases: list[Case] = Field(min_length=1, max_length=100)
+    timeout_ms: int = Field(default=120000, ge=10, le=600000)
+
+    @model_validator(mode='after')
+    def ordered_dependencies(self):
+        seen = set()
+        for case in self.cases:
+            if case.id in seen or any(dep not in seen for dep in case.depends_on):
+                raise ValueError('case IDs must be unique and dependencies must precede the case')
+            seen.add(case.id)
+        if len(self.model_dump_json()) > 262144:
+            raise ValueError('suite definition exceeds 256 KiB')
+        return self
+
+
+def digest(value: Any) -> str:
+    return 'sha256:' + hashlib.sha256(json.dumps(value, sort_keys=True, separators=(',', ':'), allow_nan=False).encode()).hexdigest()
+
+
+def observe(data: Any, path: str) -> tuple[bool, Any]:
+    """Resolve an explicit JSON pointer without expression evaluation."""
+    if not path.startswith('/'):
+        return False, None
+    try:
+        for part in path[1:].split('/'):
+            part = part.replace('~1', '/').replace('~0', '~')
+            data = data[int(part)] if isinstance(data, list) else data[part]
+        return True, data
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False, None
+
+
+def evaluate(assertion: Assertion, observation: dict) -> dict:
+    found, actual = observe(observation, assertion.path)
+    passed = found
+    if assertion.operator == 'equals':
+        passed = found and type(actual) is type(assertion.expected) and actual == assertion.expected
+    elif assertion.operator == 'contains':
+        passed = found and isinstance(actual, (str, list, dict)) and assertion.expected in actual
+    return {**assertion.model_dump(), 'actual': actual, 'observed': found, 'outcome': 'pass' if passed else 'fail'}

--- a/src/core/verification/runtime.py
+++ b/src/core/verification/runtime.py
@@ -1,0 +1,145 @@
+"""Deterministic suite execution with attempt-local evidence and bounded cleanup."""
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from contextlib import suppress
+from datetime import datetime, timezone
+from typing import Awaitable, Callable
+
+from .contracts import Step, Suite, digest, evaluate
+
+AdapterCall = Callable[[Step, dict], Awaitable[dict]]
+
+
+class BlockedError(Exception):
+    """The operation cannot execute inside the approved environment."""
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def verdict(outcomes: list[str]) -> str:
+    if not outcomes:
+        return 'not-run'
+    for status in ('cancelled', 'timeout', 'error', 'fail', 'blocked', 'not-run'):
+        if status in outcomes:
+            return status
+    return 'pass' if all(s == 'pass' for s in outcomes) else 'skipped'
+
+
+async def run_step(step: Step, phase: str, attempt: int, context: dict, call: AdapterCall) -> dict:
+    receipt = {'step_id': step.id, 'adapter': step.adapter, 'connection': step.connection,
+               'phase': phase, 'attempt': attempt, 'started_at': now(), 'outcome': 'not-run',
+               'assertions': [], 'run_id': context['run_id']}
+    try:
+        observation = await asyncio.wait_for(call(step, context), step.timeout_ms / 1000)
+        receipt['assertions'] = [evaluate(a, observation) for a in step.assertions]
+        receipt['observation'] = observation
+        receipt['outcome'] = verdict([a['outcome'] for a in receipt['assertions']])
+    except TimeoutError:
+        receipt.update(outcome='timeout', reason='step_deadline_exceeded')
+    except BlockedError:
+        receipt.update(outcome='blocked', reason='operation_outside_environment_contract')
+    except asyncio.CancelledError:
+        receipt.update(outcome='cancelled', reason='execution_cancelled')
+        raise
+    except Exception:
+        # Exception text may contain credentials, SQL values, or response bodies.
+        receipt.update(outcome='error', reason='adapter_execution_error')
+    finally:
+        receipt['ended_at'] = now()
+        context['receipts'].append(receipt)
+    return receipt
+
+
+async def interruptible_step(step, phase, attempt, context, call, remaining, cancel):
+    operation = asyncio.create_task(run_step(step, phase, attempt, context, call))
+    cancellation = asyncio.create_task(cancel.wait())
+    try:
+        done, _ = await asyncio.wait([operation, cancellation], timeout=remaining,
+                                     return_when=asyncio.FIRST_COMPLETED)
+        if cancellation in done or operation not in done:
+            operation.cancel()
+            with suppress(asyncio.CancelledError):
+                await operation
+            if cancellation in done:
+                raise asyncio.CancelledError()
+            raise TimeoutError()
+        return await operation
+    finally:
+        cancellation.cancel()
+
+
+async def execute_suite(suite: Suite, environment: dict, call: AdapterCall, *,
+                        run_id: str | None = None, cancel: asyncio.Event | None = None,
+                        progress: Callable[[dict], None] | None = None) -> dict:
+    """Every run gets a fresh result graph, including not-run cases and teardown evidence."""
+    run_id = run_id or str(uuid.uuid4())
+    cancel = cancel or asyncio.Event()
+    started = time.monotonic()
+    result = {'schema_version': 'flyto.product-verification.result.v1', 'run_id': run_id,
+              'suite': {'id': suite.id, 'version': suite.version, 'digest': digest(suite.model_dump())},
+              'environment': environment, 'runner': 'flyto-core.verification.v1',
+              'started_at': now(), 'outcome': 'not-run', 'cases': []}
+    for case in suite.cases:
+        result['cases'].append({'case_id': case.id, 'name': case.name, 'version': case.version,
+                                'outcome': 'not-run', 'attempts': []})
+    statuses = {}
+    for case, row in zip(suite.cases, result['cases'], strict=True):
+        if cancel.is_set():
+            row['outcome'] = 'cancelled'
+        elif (time.monotonic() - started) * 1000 >= suite.timeout_ms:
+            row['outcome'] = 'timeout'
+        elif case.skipped:
+            row['outcome'] = 'skipped'
+        elif any(statuses.get(dep) != 'pass' for dep in case.depends_on):
+            row['outcome'] = 'blocked'
+            row['reason'] = 'dependency_did_not_pass'
+        else:
+            for attempt in range(1, case.retries + 2):
+                receipts = []
+                context = {'run_id': run_id, 'attempt_id': f'{run_id}:{case.id}:{attempt}',
+                           'case_id': case.id, 'attempt': attempt, 'receipts': receipts}
+                execution_outcome = 'pass'
+                try:
+                    for phase, steps in [('precondition', case.preconditions), ('test', case.steps)]:
+                        for step in steps:
+                            if cancel.is_set():
+                                execution_outcome = 'cancelled'
+                                break
+                            remaining = suite.timeout_ms / 1000 - (time.monotonic() - started)
+                            if remaining <= 0:
+                                execution_outcome = 'timeout'
+                                break
+                            receipt = await interruptible_step(step, phase, attempt, context, call, remaining, cancel)
+                            if receipt['outcome'] != 'pass':
+                                execution_outcome = 'blocked' if phase == 'precondition' else receipt['outcome']
+                                break
+                        if execution_outcome != 'pass':
+                            break
+                except TimeoutError:
+                    execution_outcome = 'timeout'
+                except asyncio.CancelledError:
+                    execution_outcome = 'cancelled'
+                    cancel.set()
+                finally:
+                    for step in case.cleanup:
+                        await run_step(step, 'cleanup', attempt, context, call)
+                cleanup_failed = any(r['phase'] == 'cleanup' and r['outcome'] != 'pass' for r in receipts)
+                attempt_outcome = 'error' if cleanup_failed else execution_outcome
+                row['attempts'].append({'attempt': attempt, 'outcome': attempt_outcome,
+                                        'cleanup_failed': cleanup_failed, 'evidence': receipts})
+                row['outcome'] = attempt_outcome
+                if progress:
+                    progress(result)
+                if attempt_outcome in ('pass', 'blocked', 'cancelled', 'timeout') or cleanup_failed:
+                    break
+        statuses[case.id] = row['outcome']
+    result['outcome'] = verdict([r['outcome'] for r in result['cases']])
+    result['ended_at'] = now()
+    result['duration_ms'] = int((time.monotonic() - started) * 1000)
+    result['evidence_digest'] = digest(result)
+    return result

--- a/src/core/verification/runtime.py
+++ b/src/core/verification/runtime.py
@@ -39,7 +39,7 @@ async def run_step(step: Step, phase: str, attempt: int, context: dict, call: Ad
         receipt['assertions'] = [evaluate(a, observation) for a in step.assertions]
         receipt['observation'] = observation
         receipt['outcome'] = verdict([a['outcome'] for a in receipt['assertions']])
-    except TimeoutError:
+    except asyncio.TimeoutError:
         receipt.update(outcome='timeout', reason='step_deadline_exceeded')
     except BlockedError:
         receipt.update(outcome='blocked', reason='operation_outside_environment_contract')
@@ -67,7 +67,7 @@ async def interruptible_step(step, phase, attempt, context, call, remaining, can
                 await operation
             if cancellation in done:
                 raise asyncio.CancelledError()
-            raise TimeoutError()
+            raise asyncio.TimeoutError()
         return await operation
     finally:
         cancellation.cancel()
@@ -120,7 +120,7 @@ async def execute_suite(suite: Suite, environment: dict, call: AdapterCall, *,
                                 break
                         if execution_outcome != 'pass':
                             break
-                except TimeoutError:
+                except asyncio.TimeoutError:
                     execution_outcome = 'timeout'
                 except asyncio.CancelledError:
                     execution_outcome = 'cancelled'

--- a/src/core/verification/service.py
+++ b/src/core/verification/service.py
@@ -1,0 +1,137 @@
+"""Suite execution routes mounted on the existing authenticated runner app.
+
+The Engine persists definitions, execution snapshots and terminal results.
+This bounded process-local registry only represents currently hosted work;
+a restart is observable as an unavailable runner execution, never a pass.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import Depends, HTTPException
+from pydantic import Field
+
+from .adapters import Adapters, Connection
+from .contracts import Contract, Suite, digest
+from .runtime import execute_suite, now
+
+MAX_RECORDS = 1000
+RETENTION_SECONDS = 3600
+
+
+def prune_records(records, *, reserve=False):
+    terminal = sorted((row['finished_at'], key) for key, row in records.items()
+                      if row.get('finished_at') is not None)
+    cutoff = time.monotonic() - RETENTION_SECONDS
+    for finished, key in terminal:
+        if finished <= cutoff or (reserve and len(records) >= MAX_RECORDS):
+            records.pop(key, None)
+
+
+async def adapter_readiness():
+    ready = {'http': True, 'postgres': importlib.util.find_spec('asyncpg') is not None, 'web': False}
+    if importlib.util.find_spec('playwright') is not None:
+        from playwright.async_api import async_playwright
+        try:
+            async with async_playwright() as browser:
+                ready['web'] = Path(browser.chromium.executable_path).is_file()
+        except Exception:
+            pass
+    return ready
+
+
+def failed_result(body, partial):
+    result = dict(partial or {})
+    result.pop('evidence_digest', None)
+    result.update(schema_version='flyto.product-verification.result.v1', run_id=body.run_id,
+                  suite={'id': body.suite.id, 'version': body.suite.version, 'digest': digest(body.suite.model_dump())},
+                  environment=body.environment, runner='flyto-core.verification.v1',
+                  outcome='error', reason='runner_execution_error', ended_at=now())
+    result.setdefault('started_at', result['ended_at'])
+    result.setdefault('cases', [{'case_id': case.id, 'name': case.name, 'version': case.version,
+                                 'outcome': 'not-run', 'attempts': []} for case in body.suite.cases])
+    result['evidence_digest'] = digest(result)
+    return result
+
+
+class SuiteRunRequest(Contract):
+    run_id: str = Field(min_length=1, max_length=80, pattern=r'^[a-zA-Z0-9_-]+$')
+    org_id: str = Field(min_length=1, max_length=100)
+    project_id: str = Field(min_length=1, max_length=100)
+    suite: Suite
+    environment: dict[str, Any] = Field(max_length=16)
+    connections: dict[str, dict[str, Any]] = Field(max_length=20)
+
+
+def mount_suite_routes(app, authenticate):
+    records = {}
+    tasks = {}
+
+    def owned(run_id, org_id, project_id):
+        prune_records(records)
+        row = records.get(run_id)
+        if row is None or row['org_id'] != org_id or row['project_id'] != project_id:
+            raise HTTPException(404, 'runner execution unavailable')
+        return row
+
+    @app.get('/suite-capabilities', dependencies=[Depends(authenticate)])
+    async def capabilities():
+        ready = await adapter_readiness()
+        return {'schema_version': 'flyto.product-verification.runner.v1',
+                'adapters': [key for key, available in ready.items() if available],
+                'adapter_readiness': ready, 'max_concurrency': 4,
+                'active': len(tasks), 'web_scope': 'isolated_ip_fixture',
+                'database_scope': 'provisioned_query_readonly',
+                'state': 'ready' if all(ready.values()) else 'degraded',
+                'terminal_retention_seconds': RETENTION_SECONDS, 'max_records': MAX_RECORDS}
+
+    @app.post('/suite-runs', dependencies=[Depends(authenticate)])
+    async def submit(body: SuiteRunRequest):
+        prune_records(records)
+        request_digest = digest(body.model_dump())
+        if body.run_id in records:
+            row = owned(body.run_id, body.org_id, body.project_id)
+            if row['request_digest'] != request_digest:
+                raise HTTPException(409, 'run ID is already bound to another request')
+            return {'execution_id': body.run_id, 'status': row['status']}
+        prune_records(records, reserve=True)
+        if len(tasks) >= 4 or len(records) >= MAX_RECORDS:
+            raise HTTPException(429, 'runner capacity reached')
+        try:
+            connections = {key: Connection(**value) for key, value in body.connections.items()}
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(422, 'invalid connection bindings') from exc
+        row = {'org_id': body.org_id, 'project_id': body.project_id,
+               'request_digest': request_digest, 'status': 'running', 'result': None, 'cancel': asyncio.Event()}
+        records[body.run_id] = row
+
+        async def work():
+            try:
+                row['result'] = await execute_suite(body.suite, body.environment, Adapters(connections),
+                    run_id=body.run_id, cancel=row['cancel'], progress=lambda result: row.update(result=result))
+                row['status'] = 'complete'
+            except Exception:
+                row['result'] = failed_result(body, row['result'])
+                row['status'] = 'error'
+            finally:
+                row['finished_at'] = time.monotonic()
+                tasks.pop(body.run_id, None)
+        tasks[body.run_id] = asyncio.create_task(work())
+        return {'execution_id': body.run_id, 'status': 'running'}
+
+    @app.get('/suite-runs/{run_id}', dependencies=[Depends(authenticate)])
+    async def read(run_id: str, org_id: str, project_id: str):
+        row = owned(run_id, org_id, project_id)
+        return {'execution_id': run_id, 'status': row['status'], 'result': row['result']}
+
+    @app.post('/suite-runs/{run_id}/cancel', dependencies=[Depends(authenticate)])
+    async def cancel(run_id: str, org_id: str, project_id: str):
+        row = owned(run_id, org_id, project_id)
+        task = tasks.get(run_id)
+        if task:
+            row['cancel'].set()
+        return {'execution_id': run_id, 'status': row['status'], 'cancel_requested': task is not None}

--- a/src/core/verification_service.py
+++ b/src/core/verification_service.py
@@ -10,8 +10,8 @@ flyto-core workflow, and returns/callbacks deterministic evidence.
 
 from __future__ import annotations
 
-import base64
 import asyncio
+import base64
 import fnmatch
 import hashlib
 import hmac
@@ -30,9 +30,9 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field
 
 from core.utils import (
-    validate_url_with_env_config,
     SSRFError,
     ssrf_protection_enabled,
+    validate_url_with_env_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -296,8 +296,8 @@ async def execute_verification(body: VerificationRunRequest) -> VerificationExec
         pack = extract_evidence_pack(result)
         execution.evidence_pack = pack or {
             "schema_version": "warroom.evidence_pack.v1",
-            "verdict": "pass" if result.get("status") == "completed" else "fail",
-            "scores": {"p0": 0, "p1": 0, "replay_reliability": 1.0},
+            "verdict": "blocked",
+            "blockers": ["missing_verification_evidence"],
             "run": result,
             "artifacts": {
                 "target_url": target_url,
@@ -307,7 +307,7 @@ async def execute_verification(body: VerificationRunRequest) -> VerificationExec
         }
         execution.artifacts = build_artifacts(execution.evidence_pack)
         execution.findings_count, execution.critical_count = count_findings(execution.evidence_pack)
-        execution.verdict = str(execution.evidence_pack.get("verdict") or "pass")
+        execution.verdict = str(execution.evidence_pack.get("verdict") or "blocked")
         execution.status = "complete"
     except Exception as exc:  # pragma: no cover - defensive service boundary
         logger.exception("verification execution failed")
@@ -408,7 +408,7 @@ async def run_and_callback(body: VerificationRunRequest) -> VerificationExecutio
 
 def create_app():
     try:
-        from fastapi import FastAPI, Depends, Header, HTTPException
+        from fastapi import Depends, FastAPI, Header, HTTPException
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
         raise RuntimeError("flyto-core[api] is required to run flyto-verification") from exc
 
@@ -462,6 +462,9 @@ def create_app():
             "graph_contract": GRAPH_CONTRACT,
         }
 
+    from core.verification.service import mount_suite_routes
+
+    mount_suite_routes(app, require_run_auth)
     return app
 
 

--- a/tests/test_public_metadata.py
+++ b/tests/test_public_metadata.py
@@ -55,7 +55,11 @@ def test_readme_citation_contract_uses_current_public_positioning() -> None:
     [
         ("README.md", "## 480 Modules, 88 Catalog Categories", "## 476 Modules, 86 Catalog Categories"),
         ("docs/FEATURES.md", "[All 480 active module schemas]", "[All 476 active module schemas]"),
-        ("SECURITY.md", "The current release is **2.31.2**.", "The current release is **2.31.1**."),
+        (
+            "SECURITY.md",
+            f"The current release is **{_project_value('version')}**.",
+            "The current release is **0.0.0**.",
+        ),
         ("demo.py", "flyto-core demo — 480 tools for AI agents", "flyto-core demo — 468 tools for AI agents"),
     ],
 )

--- a/tests/test_verification_service.py
+++ b/tests/test_verification_service.py
@@ -10,6 +10,24 @@ from core.verification_service import (
 )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result", [{"status": "completed"}, {"status": "failed"}])
+async def test_workflow_completion_without_assertion_evidence_is_blocked(monkeypatch, result):
+    from core.engine import WorkflowEngine
+
+    async def execute(_self):
+        return result
+
+    monkeypatch.setattr(WorkflowEngine, "execute", execute)
+    execution = await execute_verification(VerificationRunRequest(
+        workflowYaml="name: no evidence\nsteps: []\n",
+    ))
+    assert execution.verdict == "blocked"
+    assert execution.evidence_pack["blockers"] == ["missing_verification_evidence"]
+
+
+
+
 def test_verification_scope_allows_only_engine_computed_hosts():
     assert target_allowed("https://app.flyto2.com/projects", ["https://app.flyto2.com"])
     assert target_allowed("https://app.flyto2.com/projects", ["app.flyto2.com"])

--- a/tests/verification/test_adapter_redaction.py
+++ b/tests/verification/test_adapter_redaction.py
@@ -1,0 +1,32 @@
+"""All representations of recorded HTTP JSON must honor secret redaction."""
+import json
+
+import pytest
+from aiohttp import web
+
+from core.verification.adapters import Adapters, Connection
+from core.verification.contracts import Step
+
+
+@pytest.mark.asyncio
+async def test_json_text_cannot_restore_redacted_credentials():
+    async def respond(_request):
+        return web.json_response({'state': 'ready', 'nested': {'api_key': 'fixture-private-value'}})
+
+    app = web.Application()
+    app.router.add_get('/state', respond)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    adapter = Adapters({'api': Connection('http', f'http://127.0.0.1:{port}', isolated=True)})
+    step = Step.model_validate({'id': 'observe', 'adapter': 'http', 'connection': 'api',
+        'input': {'path': '/state'}, 'assertions': [{'id': 'ready', 'path': '/body/state', 'expected': 'ready'}]})
+    try:
+        evidence = await adapter(step, {'run_id': 'redaction', 'attempt_id': 'redaction-1', 'case_id': 'safe'})
+        assert evidence['body']['state'] == 'ready'
+        assert evidence['body']['nested']['api_key'] == '[redacted]'
+        assert 'fixture-private-value' not in json.dumps(evidence)
+    finally:
+        await runner.cleanup()

--- a/tests/verification/test_database_scope.py
+++ b/tests/verification/test_database_scope.py
@@ -1,0 +1,39 @@
+"""Database credentials cannot expand a provisioned verification scope."""
+import ssl
+
+import pytest
+
+from core.verification.adapters import Connection, database_connection_options
+from core.verification.runtime import BlockedError
+
+
+@pytest.mark.parametrize('endpoint,dsn,isolated', [
+    ('postgresql://127.0.0.1:55476', 'postgresql://pv@127.0.0.2:55476/test', True),
+    ('postgresql://127.0.0.1:55476', 'postgresql://pv@127.0.0.1:5432/test', True),
+    ('postgresql://127.0.0.1', 'postgresql://pv@127.0.0.1/test?host=169.254.169.254', True),
+    ('postgresql://127.0.0.1', 'postgresql://pv@127.0.0.1/test', False),
+    ('postgresql://169.254.169.254', 'postgresql://pv@169.254.169.254/test', True),
+    ('postgresql://localhost', 'postgresql://pv@localhost/test', True),
+    ('postgresql://8.8.8.8', 'postgresql://pv@8.8.8.8/test?sslmode=disable', False),
+    ('postgresql://8.8.8.8', 'postgresql://pv@8.8.8.8/test?sslmode=require', False),
+    ('postgresql://8.8.8.8', 'postgresql://pv@8.8.8.8/test?sslmode=verify-full&sslmode=disable', False),
+    ('postgresql://127.0.0.1', 'postgresql:///test?host=/tmp', True),
+])
+def test_database_scope_rejects_unapproved_targets(endpoint, dsn, isolated):
+    with pytest.raises(BlockedError):
+        database_connection_options(Connection('postgres', endpoint, isolated=isolated, database_dsn=dsn))
+
+
+def test_literal_scope_preserves_credentials_and_explicit_tls():
+    options = database_connection_options(Connection('postgres', 'postgresql://8.8.8.8',
+        database_dsn='postgresql://reader:p%40ss@8.8.8.8/proof?sslmode=verify-full'))
+    assert options['host'] == '8.8.8.8'
+    assert options['password'] == 'p@ss'
+    assert options['ssl'].check_hostname is True
+    assert options['ssl'].verify_mode == ssl.CERT_REQUIRED
+
+
+def test_explicit_isolated_scope_uses_fixed_address():
+    options = database_connection_options(Connection('postgres', 'postgresql://127.0.0.1:55476',
+        isolated=True, database_dsn='postgresql://pv@127.0.0.1:55476/proof?sslmode=disable'))
+    assert (options['host'], options['port'], options['ssl']) == ('127.0.0.1', 55476, False)

--- a/tests/verification/test_local_adapters.py
+++ b/tests/verification/test_local_adapters.py
@@ -1,0 +1,92 @@
+"""Controlled HTTP -> PostgreSQL -> Chromium proof. Never uses production data."""
+import os
+import uuid
+from urllib.parse import urlsplit
+
+import pytest
+from aiohttp import web
+
+from core.verification.adapters import Adapters, Connection
+from core.verification.contracts import Suite
+from core.verification.runtime import execute_suite
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_api_database_ui_flow_and_cleanup(tmp_path):
+    dsn = os.environ.get('FLYTO_PV_FIXTURE_PG_URL')
+    if not dsn:
+        pytest.skip('Set FLYTO_PV_FIXTURE_PG_URL to a disposable PostgreSQL database')
+    import asyncpg
+    db = await asyncpg.connect(dsn)
+    table = 'pv_' + uuid.uuid4().hex
+    await db.execute(f'CREATE TABLE {table} (id TEXT PRIMARY KEY, state TEXT NOT NULL)')
+    sentinel = 'unrelated_' + uuid.uuid4().hex
+    await db.execute(f'INSERT INTO {table} VALUES ($1, $2)', sentinel, 'preserve')
+
+    async def put(request):
+        body = await request.json()
+        await db.execute(f'INSERT INTO {table} VALUES ($1, $2)', body['id'], 'ready')
+        return web.json_response({'created': True, 'id': body['id']}, status=201)
+
+    async def delete(request):
+        result = await db.execute(f'DELETE FROM {table} WHERE id=$1', request.match_info['id'])
+        return web.json_response({'deleted': result == 'DELETE 1'})
+
+    async def page(request):
+        row = await db.fetchrow(f'SELECT state FROM {table} WHERE id=$1', request.match_info['id'])
+        return web.Response(text='<main>' + (row['state'] if row else 'missing') + '</main>', content_type='text/html')
+
+    app = web.Application()
+    app.router.add_post('/records', put)
+    app.router.add_delete('/records/{id}', delete)
+    app.router.add_get('/ui/{id}', page)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    endpoint = f'http://127.0.0.1:{port}'
+    adapters = Adapters({
+        'api': Connection('http', endpoint, isolated=True),
+        'db': Connection('postgres', f'postgresql://127.0.0.1:{urlsplit(dsn).port or 5432}', isolated=True, database_dsn=dsn, queries={
+            'find_record': f'SELECT state FROM {table} WHERE id=$1',
+            'forbidden_write': f'DELETE FROM {table} RETURNING id',
+        }),
+        'ui': Connection('web', endpoint, isolated=True),
+    })
+    def step(step_id, adapter, connection, inputs, path, expected):
+        return {'id': step_id, 'adapter': adapter, 'connection': connection, 'input': inputs,
+                'timeout_ms': 15000, 'assertions': [{'id': step_id, 'path': path, 'expected': expected}]}
+    spec = Suite.model_validate({'id': 'checkout', 'name': 'API database UI', 'cases': [{
+        'id': 'order', 'name': 'Create and observe an isolated order',
+        'steps': [
+            step('create', 'http', 'api', {'method': 'POST', 'path': '/records', 'json': {'id': '{{attempt_id}}'}}, '/body/created', True),
+            step('database', 'postgres', 'db', {'query_id': 'find_record', 'arguments': ['{{attempt_id}}']}, '/rows/0/state', 'ready'),
+            step('ui', 'web', 'ui', {'path': '/ui/{{attempt_id}}', 'selector': 'main'}, '/text', 'ready'),
+        ],
+        'cleanup': [step('remove', 'http', 'api', {'method': 'DELETE', 'path': '/records/{{attempt_id}}'}, '/body/deleted', True)],
+    }]})
+    try:
+        results = [await execute_suite(spec, {'id': 'fixture', 'version': 1}, adapters) for _ in range(2)]
+        for result in results:
+            assert result['outcome'] == 'pass', result
+            evidence = result['cases'][0]['attempts'][0]['evidence']
+            assert [r['adapter'] for r in evidence] == ['http', 'postgres', 'web', 'http']
+            assert all(r['outcome'] == 'pass' for r in evidence)
+        assert results[0]['run_id'] != results[1]['run_id']
+        assert await db.fetchval(f'SELECT count(*) FROM {table}') == 1
+        assert await db.fetchval(f'SELECT state FROM {table} WHERE id=$1', sentinel) == 'preserve'
+        denied = spec.model_copy(deep=True)
+        denied.cases[0].steps = [denied.cases[0].steps[1].model_copy(update={'input': {'query_id': 'forbidden_write'}})]
+        denied.cases[0].cleanup = []
+        rejected = await execute_suite(denied, {'id': 'fixture', 'version': 1}, adapters)
+        assert rejected['outcome'] == 'error'
+        assert await db.fetchval(f'SELECT count(*) FROM {table}') == 1
+        import json
+        (tmp_path / 'cross-layer-evidence.json').write_text(json.dumps(results, indent=2))
+    finally:
+        await runner.cleanup()
+        await db.execute(f'DROP TABLE {table}')
+        await db.close()

--- a/tests/verification/test_packaging.py
+++ b/tests/verification/test_packaging.py
@@ -1,0 +1,17 @@
+"""The deployed verification image must contain every advertised adapter."""
+from pathlib import Path
+
+
+def test_verification_image_installs_database_extra():
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib
+    root = Path(__file__).resolve().parents[2]
+    project = tomllib.loads((root / 'pyproject.toml').read_text())['project']
+    extra = project['optional-dependencies']['verification']
+    assert any(requirement.startswith('asyncpg>=') for requirement in extra)
+    assert not any(requirement.startswith('asyncpg') for requirement in project['dependencies'])
+    image = (root / 'Dockerfile.verification').read_text()
+    assert 'wheel-dir /wheels .[verification]' in image
+    assert '--find-links=/wheels flyto-core[verification]' in image

--- a/tests/verification/test_runtime.py
+++ b/tests/verification/test_runtime.py
@@ -1,0 +1,103 @@
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from core.verification.contracts import Assertion, Suite, evaluate
+from core.verification.runtime import BlockedError, execute_suite
+
+
+def suite(**changes):
+    body = {'id': 'suite', 'name': 'Suite', 'cases': [{
+        'id': 'case', 'name': 'Case', 'steps': [{
+            'id': 'check', 'adapter': 'http', 'connection': 'api',
+            'assertions': [{'id': 'body', 'path': '/body/ready', 'expected': True}],
+        }],
+    }]}
+    body.update(changes)
+    return Suite.model_validate(body)
+
+
+@pytest.mark.parametrize('observed', [{}, {'body': {}}, {'body': {'ready': 1}}, {'body': {'ready': False}}])
+def test_missing_or_wrong_typed_observation_never_passes(observed):
+    a = Assertion(id='ready', path='/body/ready', expected=True)
+    assert evaluate(a, observed)['outcome'] == 'fail'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('mode,want', [('ok', 'pass'), ('false', 'fail'), ('error', 'error'), ('blocked', 'blocked'), ('slow', 'timeout')])
+async def test_real_outcome_contract(mode, want):
+    async def adapter(step, context):
+        if mode == 'error':
+            raise RuntimeError('secret must never leak')
+        if mode == 'blocked':
+            raise BlockedError()
+        if mode == 'slow':
+            await asyncio.sleep(0.2)
+        return {'body': {'ready': mode == 'ok'}}
+    spec = suite()
+    spec.cases[0].steps[0].timeout_ms = 10
+    result = await execute_suite(spec, {'id': 'env', 'version': 1}, adapter)
+    assert result['outcome'] == want
+    assert 'secret must never leak' not in str(result)
+    assert result['cases'][0]['attempts'][0]['evidence'][0]['assertions'] or want in ('error', 'blocked', 'timeout')
+
+
+@pytest.mark.asyncio
+async def test_retry_and_rerun_evidence_remain_separate():
+    async def adapter(step, context):
+        return {'body': {'ready': context['attempt'] == 2}}
+    spec = suite()
+    spec.cases[0].retries = 1
+    spec.cases[0].retry_safe = True
+    first = await execute_suite(spec, {'id': 'env', 'version': 1}, adapter)
+    second = await execute_suite(spec, {'id': 'env', 'version': 1}, adapter)
+    assert first['run_id'] != second['run_id']
+    assert first['outcome'] == 'pass'
+    attempts = first['cases'][0]['attempts']
+    assert [a['outcome'] for a in attempts] == ['fail', 'pass']
+    assert [a['evidence'][0]['attempt'] for a in attempts] == [1, 2]
+    assert first['suite']['digest'] == second['suite']['digest']
+    assert first['evidence_digest'] != second['evidence_digest']
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_overrides_pass_and_prevents_retry():
+    spec = suite()
+    cleanup = spec.cases[0].steps[0].model_copy(update={'id': 'cleanup'})
+    spec.cases[0].cleanup = [cleanup]
+    spec.cases[0].retries = 1
+    spec.cases[0].retry_safe = True
+    async def adapter(step, context):
+        if step.id == 'cleanup':
+            raise RuntimeError('unreachable')
+        return {'body': {'ready': True}}
+    result = await execute_suite(spec, {}, adapter)
+    assert result['outcome'] == 'error'
+    assert len(result['cases'][0]['attempts']) == 1
+    assert result['cases'][0]['attempts'][0]['cleanup_failed']
+
+
+@pytest.mark.asyncio
+async def test_dependencies_and_cancellation_never_convert_to_pass():
+    spec = suite()
+    spec.cases.append(spec.cases[0].model_copy(update={'id': 'dependent', 'depends_on': ['case']}))
+    async def adapter(step, context):
+        return {'body': {'ready': False}}
+    result = await execute_suite(spec, {}, adapter)
+    assert [c['outcome'] for c in result['cases']] == ['fail', 'blocked']
+    cancel = asyncio.Event()
+    cancel.set()
+    cancelled = await execute_suite(spec, {}, adapter, cancel=cancel)
+    assert cancelled['outcome'] == 'cancelled'
+    assert not cancelled['cases'][0]['attempts']
+
+
+def test_contract_rejects_empty_assertions_and_forward_dependencies():
+    for cases in ([], [{'id': 'case', 'name': 'Case', 'steps': []}]):
+        with pytest.raises(ValidationError):
+            suite(cases=cases)
+    data = suite().model_dump()
+    data['cases'][0]['depends_on'] = ['later']
+    with pytest.raises(ValidationError):
+        Suite.model_validate(data)

--- a/tests/verification/test_service.py
+++ b/tests/verification/test_service.py
@@ -1,0 +1,86 @@
+import asyncio
+
+import httpx
+import pytest
+
+from core.verification import service
+from core.verification.contracts import digest
+from core.verification_service import create_app
+
+
+def request_body():
+    return {'run_id': 'run-1', 'org_id': 'org-1', 'project_id': 'project-1',
+            'environment': {'id': 'env', 'version': 1, 'stage': 'test'}, 'connections': {},
+            'suite': {'id': 'suite', 'name': 'Suite', 'cases': [{
+                'id': 'case', 'name': 'Case', 'steps': [{
+                    'id': 'check', 'adapter': 'http', 'connection': 'missing',
+                    'assertions': [{'id': 'ready', 'path': '/body/ready', 'expected': True}],
+                }],
+            }]}}
+
+
+@pytest.mark.asyncio
+async def test_authenticated_runner_tenant_scope_replay_and_failure_evidence(monkeypatch):
+    monkeypatch.setenv('FLYTO_VERIFICATION_API_KEY', 'local-fixture-key')
+    app = create_app()
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url='http://runner') as client:
+        assert (await client.post('/suite-runs', json=request_body())).status_code == 401
+        client.headers['X-Internal-Key'] = 'local-fixture-key'
+        response = await client.post('/suite-runs', json=request_body())
+        assert response.status_code == 200
+        for _ in range(100):
+            response = await client.get('/suite-runs/run-1', params={'org_id': 'org-1', 'project_id': 'project-1'})
+            if response.json()['status'] != 'running':
+                break
+            await asyncio.sleep(0.005)
+        result = response.json()['result']
+        assert result['outcome'] == 'blocked'
+        assert result['cases'][0]['attempts'][0]['evidence'][0]['outcome'] == 'blocked'
+        assert (await client.get('/suite-runs/run-1', params={'org_id': 'other', 'project_id': 'project-1'})).status_code == 404
+        replay = await client.post('/suite-runs', json=request_body())
+        assert replay.json()['status'] == 'complete'
+        changed = request_body()
+        changed['suite']['name'] = 'Different'
+        assert (await client.post('/suite-runs', json=changed)).status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_runner_exception_keeps_honest_digested_terminal_result(monkeypatch):
+    monkeypatch.setenv('FLYTO_VERIFICATION_API_KEY', 'local-fixture-key')
+
+    async def crash(*args, **kwargs):
+        raise RuntimeError('fixture-secret-must-not-appear')
+
+    monkeypatch.setattr(service, 'execute_suite', crash)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=create_app()), base_url='http://runner',
+                                headers={'X-Internal-Key': 'local-fixture-key'}) as client:
+        await client.post('/suite-runs', json=request_body())
+        await asyncio.sleep(0)
+        response = await client.get('/suite-runs/run-1', params={'org_id': 'org-1', 'project_id': 'project-1'})
+        payload = response.json()
+        assert payload['status'] == 'error'
+        result = payload['result']
+        assert result['outcome'] == 'error'
+        assert result['cases'][0]['outcome'] == 'not-run'
+        assert 'fixture-secret' not in response.text
+        checksum = result.pop('evidence_digest')
+        assert checksum == digest(result)
+
+
+def test_terminal_retention_never_evicts_active_work(monkeypatch):
+    monkeypatch.setattr(service, 'MAX_RECORDS', 3)
+    monkeypatch.setattr(service.time, 'monotonic', lambda: 10000)
+    records = {'active': {'status': 'running'},
+               'old': {'status': 'complete', 'finished_at': 1},
+               'recent': {'status': 'complete', 'finished_at': 9998},
+               'newest': {'status': 'complete', 'finished_at': 9999}}
+    service.prune_records(records)
+    assert set(records) == {'active', 'recent', 'newest'}
+    service.prune_records(records, reserve=True)
+    assert set(records) == {'active', 'newest'}
+
+
+@pytest.mark.asyncio
+async def test_uninstalled_optional_adapters_are_not_advertised_ready(monkeypatch):
+    monkeypatch.setattr(service.importlib.util, 'find_spec', lambda _: None)
+    assert await service.adapter_readiness() == {'http': True, 'postgres': False, 'web': False}


### PR DESCRIPTION
Product Verification requires a dedicated runtime for versioned suites, bounded HTTP/PostgreSQL/Chromium adapters, cancellation, cleanup, and tenant-owned evidence. Add authenticated suite routes to Core, retain the legacy verification endpoint, and package the complete runtime in a dedicated non-root container. The new code declares unreleased version 2.32.0 to prevent reuse of an already published package identity; this PR does not publish a PyPI release.

Validation: 4,694 non-browser/non-E2E tests passed with 65.21% coverage (60% required), 205 environment/optional skips and 472 marker exclusions. Final runtime/version tests, a real isolated HTTP → PostgreSQL → Chromium → cleanup test, audited Ruff, documentation/brand checks, wheel/sdist and Twine, npm audit, base dependency audit, strict full-scan Indexer (19 pass, zero warnings), and task validation passed. Python 3.10 timeout compatibility is covered by the CI matrix.

Deployment: use a separate private Cloud Run service with application-key admission and Engine service identity; max one instance and always-allocated CPU preserve the bounded process-local execution registry. Restart remains a visible error, while Engine persists terminal evidence. No customer suite or production scan is triggered by this release.
